### PR TITLE
feat: implement refund APIs as tools for mcp server

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Currently, the Razorpay MCP Server provides the following tools:
 | `fetch_payment_link`  | Fetch details of a payment link       |
 | `create_order`        | Creates an order                      |
 | `fetch_order`         | Fetch order details                   |
+| `create_refund`       | Creates a refund                      |
+| `fetch_refund`        | Fetch refund details                  |
+| `update_refund`       | Update refund notes                   |
 
 
 ## Use Cases 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Currently, the Razorpay MCP Server provides the following tools:
 | `create_order`        | Creates an order                                | [Order](https://razorpay.com/docs/api/orders/create/)
 | `fetch_order`         | Fetch order with ID                             | [Order](https://razorpay.com/docs/api/orders/fetch-with-id)
 | `fetch_all_orders`    | Fetch all orders                                | [Order](https://razorpay.com/docs/api/orders/fetch-all)
-| `create_refund`       | Creates a refund                                | [Refund](https://razorpay.com/docs/api/refunds/create-normal/)
+| `create_refund`       | Creates a refund                                | [Refund](https://razorpay.com/docs/api/refunds/create-instant/)
 | `fetch_refund`        | Fetch refund details with ID                    | [Refund](https://razorpay.com/docs/api/refunds/fetch-with-id/)
 | `update_refund`       | Update refund notes with ID                     | [Refund](https://razorpay.com/docs/api/refunds/update/)
 

--- a/pkg/razorpay/refunds.go
+++ b/pkg/razorpay/refunds.go
@@ -19,7 +19,7 @@ func CreateRefund(
 		mcpgo.WithString(
 			"payment_id",
 			mcpgo.Description("Unique identifier of the payment which "+
-				"needs to be refunded."),
+				"needs to be refunded. ID should have a pay_ prefix."),
 			mcpgo.Required(),
 		),
 		mcpgo.WithNumber(
@@ -57,20 +57,32 @@ func CreateRefund(
 		data := make(map[string]interface{})
 
 		var amount int
-		if amountFloat, err := OptionalParam[float64](r, "amount"); err == nil {
-			amount = int(amountFloat)
+		amount, err = OptionalInt(r, "amount")
+		if result, err := HandleValidationError(err); result != nil {
+			return result, err
 		}
 
-		if speed, err := OptionalParam[string](r, "speed"); err == nil {
+		speed, err := OptionalParam[string](r, "speed")
+		if result, err := HandleValidationError(err); result != nil {
+			return result, err
+		}
+		if speed != "" {
 			data["speed"] = speed
 		}
 
-		notesType := OptionalParam[map[string]interface{}]
-		if notes, err := notesType(r, "notes"); err == nil {
+		notes, err := OptionalParam[map[string]interface{}](r, "notes")
+		if result, err := HandleValidationError(err); result != nil {
+			return result, err
+		}
+		if notes != nil {
 			data["notes"] = notes
 		}
 
-		if receipt, err := OptionalParam[string](r, "receipt"); err == nil {
+		receipt, err := OptionalParam[string](r, "receipt")
+		if result, err := HandleValidationError(err); result != nil {
+			return result, err
+		}
+		if receipt != "" {
 			data["receipt"] = receipt
 		}
 
@@ -101,7 +113,8 @@ func FetchRefund(
 		mcpgo.WithString(
 			"refund_id",
 			mcpgo.Description(
-				"Unique identifier of the refund which is to be retrieved."),
+				"Unique identifier of the refund which is to be retrieved. "+
+					"ID should have a rfnd_ prefix."),
 			mcpgo.Required(),
 		),
 	}
@@ -141,7 +154,7 @@ func UpdateRefund(
 		mcpgo.WithString(
 			"refund_id",
 			mcpgo.Description("Unique identifier of the refund which "+
-				"needs to be updated."),
+				"needs to be updated. ID should have a rfnd_ prefix."),
 			mcpgo.Required(),
 		),
 		mcpgo.WithObject(

--- a/pkg/razorpay/refunds.go
+++ b/pkg/razorpay/refunds.go
@@ -1,0 +1,189 @@
+package razorpay
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	rzpsdk "github.com/razorpay/razorpay-go"
+
+	"github.com/razorpay/razorpay-mcp-server/pkg/mcpgo"
+)
+
+// CreateRefund returns a tool that creates a normal refund for a payment
+func CreateRefund(
+	_ *slog.Logger,
+	client *rzpsdk.Client,
+) mcpgo.Tool {
+	parameters := []mcpgo.ToolParameter{
+		mcpgo.WithString(
+			"payment_id",
+			mcpgo.Description("Unique identifier of the payment which "+
+				"needs to be refunded."),
+			mcpgo.Required(),
+		),
+		mcpgo.WithNumber(
+			"amount",
+			mcpgo.Description("Payment amount in the smallest currency unit "+
+				"(e.g., for ₹295, use 29500)"),
+		),
+		mcpgo.WithString(
+			"speed",
+			mcpgo.Description("The speed at which the refund is to be "+
+				"processed. Default is 'normal'. For instant refunds, speed "+
+				"is set as 'optimum'."),
+		),
+		mcpgo.WithObject(
+			"notes",
+			mcpgo.Description("Key-value pairs used to store additional "+
+				"information. A maximum of 15 key-value pairs can be included."),
+		),
+		mcpgo.WithString(
+			"receipt",
+			mcpgo.Description("A unique identifier provided by you for "+
+				"your internal reference."),
+		),
+	}
+
+	handler := func(
+		ctx context.Context,
+		r mcpgo.CallToolRequest,
+	) (*mcpgo.ToolResult, error) {
+		paymentID, err := RequiredParam[string](r, "payment_id")
+		if result, err := HandleValidationError(err); result != nil {
+			return result, err
+		}
+
+		data := make(map[string]interface{})
+
+		var amount int
+		if amountFloat, err := OptionalParam[float64](r, "amount"); err == nil {
+			amount = int(amountFloat)
+		}
+
+		if speed, err := OptionalParam[string](r, "speed"); err == nil {
+			data["speed"] = speed
+		}
+
+		notesType := OptionalParam[map[string]interface{}]
+		if notes, err := notesType(r, "notes"); err == nil {
+			data["notes"] = notes
+		}
+
+		if receipt, err := OptionalParam[string](r, "receipt"); err == nil {
+			data["receipt"] = receipt
+		}
+
+		refund, err := client.Payment.Refund(paymentID, amount, data, nil)
+		if err != nil {
+			return mcpgo.NewToolResultError(
+				fmt.Sprintf("creating refund failed: %s", err.Error())), nil
+		}
+
+		return mcpgo.NewToolResultJSON(refund)
+	}
+
+	return mcpgo.NewTool(
+		"create_refund",
+		"Use this tool to create a normal refund for a payment. "+
+			"Amount should be in the smallest currency unit (e.g., for ₹295, use 29500)",
+		parameters,
+		handler,
+	)
+}
+
+// FetchRefund returns a tool that fetches a refund by ID
+func FetchRefund(
+	_ *slog.Logger,
+	client *rzpsdk.Client,
+) mcpgo.Tool {
+	parameters := []mcpgo.ToolParameter{
+		mcpgo.WithString(
+			"refund_id",
+			mcpgo.Description("Unique identifier of the refund which is to be retrieved."),
+			mcpgo.Required(),
+		),
+	}
+
+	handler := func(
+		ctx context.Context,
+		r mcpgo.CallToolRequest,
+	) (*mcpgo.ToolResult, error) {
+		refundID, err := RequiredParam[string](r, "refund_id")
+		if result, err := HandleValidationError(err); result != nil {
+			return result, err
+		}
+
+		refund, err := client.Refund.Fetch(refundID, nil, nil)
+		if err != nil {
+			return mcpgo.NewToolResultError(
+				fmt.Sprintf("fetching refund failed: %s", err.Error())), nil
+		}
+
+		return mcpgo.NewToolResultJSON(refund)
+	}
+
+	return mcpgo.NewTool(
+		"fetch_refund",
+		"Use this tool to retrieve the details of a specific refund using its id.",
+		parameters,
+		handler,
+	)
+}
+
+// UpdateRefund returns a tool that updates a refund's notes
+func UpdateRefund(
+	_ *slog.Logger,
+	client *rzpsdk.Client,
+) mcpgo.Tool {
+	parameters := []mcpgo.ToolParameter{
+		mcpgo.WithString(
+			"refund_id",
+			mcpgo.Description("Unique identifier of the refund which "+
+				"needs to be updated."),
+			mcpgo.Required(),
+		),
+		mcpgo.WithObject(
+			"notes",
+			mcpgo.Description("Key-value pairs used to store additional "+
+				"information. A maximum of 15 key-value pairs can be included, "+
+				"with each value not exceeding 256 characters."),
+			mcpgo.Required(),
+		),
+	}
+
+	handler := func(
+		ctx context.Context,
+		r mcpgo.CallToolRequest,
+	) (*mcpgo.ToolResult, error) {
+		refundID, err := RequiredParam[string](r, "refund_id")
+		if result, err := HandleValidationError(err); result != nil {
+			return result, err
+		}
+
+		notesType := RequiredParam[map[string]interface{}]
+		notes, err := notesType(r, "notes")
+		if result, err := HandleValidationError(err); result != nil {
+			return result, err
+		}
+
+		data := make(map[string]interface{})
+		data["notes"] = notes
+
+		refund, err := client.Refund.Update(refundID, data, nil)
+		if err != nil {
+			return mcpgo.NewToolResultError(
+				fmt.Sprintf("updating refund failed: %s", err.Error())), nil
+		}
+
+		return mcpgo.NewToolResultJSON(refund)
+	}
+
+	return mcpgo.NewTool(
+		"update_refund",
+		"Use this tool to update the notes for a specific refund. "+
+			"Only the notes field can be modified.",
+		parameters,
+		handler,
+	)
+}

--- a/pkg/razorpay/refunds.go
+++ b/pkg/razorpay/refunds.go
@@ -100,7 +100,8 @@ func FetchRefund(
 	parameters := []mcpgo.ToolParameter{
 		mcpgo.WithString(
 			"refund_id",
-			mcpgo.Description("Unique identifier of the refund which is to be retrieved."),
+			mcpgo.Description(
+				"Unique identifier of the refund which is to be retrieved."),
 			mcpgo.Required(),
 		),
 	}

--- a/pkg/razorpay/refunds_test.go
+++ b/pkg/razorpay/refunds_test.go
@@ -1,0 +1,322 @@
+package razorpay
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/razorpay/razorpay-go/constants"
+
+	"github.com/razorpay/razorpay-mcp-server/pkg/razorpay/mock"
+)
+
+func Test_CreateRefund(t *testing.T) {
+	createRefundPathFmt := fmt.Sprintf(
+		"/%s%s/%%s/refund",
+		constants.VERSION_V1,
+		constants.PAYMENT_URL,
+	)
+
+	// Define test responses
+	successfulRefundResp := map[string]interface{}{
+		"id":              "rfnd_FP8QHiV938haTz",
+		"entity":          "refund",
+		"amount":          float64(500100),
+		"currency":        "INR",
+		"payment_id":      "pay_29QQoUBi66xm2f",
+		"notes":           map[string]interface{}{},
+		"receipt":         "Receipt No. 31",
+		"acquirer_data":   map[string]interface{}{"arn": nil},
+		"created_at":      float64(1597078866),
+		"batch_id":        nil,
+		"status":          "processed",
+		"speed_processed": "normal",
+		"speed_requested": "normal",
+	}
+
+	errorResp := map[string]interface{}{
+		"error": map[string]interface{}{
+			"code":        "BAD_REQUEST_ERROR",
+			"description": "Razorpay API error: Bad request",
+		},
+	}
+
+	tests := []RazorpayToolTestCase{
+		{
+			Name: "successful full refund",
+			Request: map[string]interface{}{
+				"payment_id": "pay_29QQoUBi66xm2f",
+				"amount":     float64(500100),
+				"receipt":    "Receipt No. 31",
+			},
+			MockHttpClient: func() (*http.Client, *httptest.Server) {
+				return mock.NewHTTPClient(
+					mock.Endpoint{
+						Path:     fmt.Sprintf(createRefundPathFmt, "pay_29QQoUBi66xm2f"),
+						Method:   "POST",
+						Response: successfulRefundResp,
+					},
+				)
+			},
+			ExpectError:    false,
+			ExpectedResult: successfulRefundResp,
+		},
+		{
+			Name: "refund with speed parameter",
+			Request: map[string]interface{}{
+				"payment_id": "pay_29QQoUBi66xm2f",
+				"amount":     float64(500100),
+				"speed":      "optimum",
+			},
+			MockHttpClient: func() (*http.Client, *httptest.Server) {
+				speedRefundResp := map[string]interface{}{
+					"id":              "rfnd_HzAbPEkKtRq48V",
+					"entity":          "refund",
+					"amount":          float64(500100),
+					"payment_id":      "pay_29QQoUBi66xm2f",
+					"status":          "processed",
+					"speed_processed": "instant",
+					"speed_requested": "optimum",
+				}
+				return mock.NewHTTPClient(
+					mock.Endpoint{
+						Path:     fmt.Sprintf(createRefundPathFmt, "pay_29QQoUBi66xm2f"),
+						Method:   "POST",
+						Response: speedRefundResp,
+					},
+				)
+			},
+			ExpectError: false,
+			ExpectedResult: map[string]interface{}{
+				"id":              "rfnd_HzAbPEkKtRq48V",
+				"entity":          "refund",
+				"amount":          float64(500100),
+				"payment_id":      "pay_29QQoUBi66xm2f",
+				"status":          "processed",
+				"speed_processed": "instant",
+				"speed_requested": "optimum",
+			},
+		},
+		{
+			Name: "refund API server error",
+			Request: map[string]interface{}{
+				"payment_id": "pay_29QQoUBi66xm2f",
+				"amount":     float64(500100),
+			},
+			MockHttpClient: func() (*http.Client, *httptest.Server) {
+				return mock.NewHTTPClient(
+					mock.Endpoint{
+						Path:     fmt.Sprintf(createRefundPathFmt, "pay_29QQoUBi66xm2f"),
+						Method:   "POST",
+						Response: errorResp,
+					},
+				)
+			},
+			ExpectError:    true,
+			ExpectedErrMsg: "creating refund failed: Razorpay API error: Bad request",
+		},
+		{
+			Name:           "missing payment_id parameter",
+			Request:        map[string]interface{}{},
+			MockHttpClient: nil,
+			ExpectError:    true,
+			ExpectedErrMsg: "missing required parameter: payment_id",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			runToolTest(t, tc, CreateRefund, "Refund")
+		})
+	}
+}
+
+func Test_FetchRefund(t *testing.T) {
+	fetchRefundPathFmt := fmt.Sprintf(
+		"/%s%s/%%s",
+		constants.VERSION_V1,
+		constants.REFUND_URL,
+	)
+
+	// Define test response for successful refund fetch
+	successfulRefundResp := map[string]interface{}{
+		"id":         "rfnd_DfjjhJC6eDvUAi",
+		"entity":     "refund",
+		"amount":     float64(6000),
+		"currency":   "INR",
+		"payment_id": "pay_EpkFDYRirena0f",
+		"notes": map[string]interface{}{
+			"comment": "Issuing an instant refund",
+		},
+		"receipt": nil,
+		"acquirer_data": map[string]interface{}{
+			"arn": "10000000000000",
+		},
+		"created_at":      float64(1589521675),
+		"batch_id":        nil,
+		"status":          "processed",
+		"speed_processed": "optimum",
+		"speed_requested": "optimum",
+	}
+
+	// Define error responses
+	notFoundResp := map[string]interface{}{
+		"error": map[string]interface{}{
+			"code":        "BAD_REQUEST_ERROR",
+			"description": "The id provided does not exist",
+		},
+	}
+
+	tests := []RazorpayToolTestCase{
+		{
+			Name: "successful refund fetch",
+			Request: map[string]interface{}{
+				"refund_id": "rfnd_DfjjhJC6eDvUAi",
+			},
+			MockHttpClient: func() (*http.Client, *httptest.Server) {
+				return mock.NewHTTPClient(
+					mock.Endpoint{
+						Path:     fmt.Sprintf(fetchRefundPathFmt, "rfnd_DfjjhJC6eDvUAi"),
+						Method:   "GET",
+						Response: successfulRefundResp,
+					},
+				)
+			},
+			ExpectError:    false,
+			ExpectedResult: successfulRefundResp,
+		},
+		{
+			Name: "refund id not found",
+			Request: map[string]interface{}{
+				"refund_id": "rfnd_nonexistent",
+			},
+			MockHttpClient: func() (*http.Client, *httptest.Server) {
+				return mock.NewHTTPClient(
+					mock.Endpoint{
+						Path:     fmt.Sprintf(fetchRefundPathFmt, "rfnd_nonexistent"),
+						Method:   "GET",
+						Response: notFoundResp,
+					},
+				)
+			},
+			ExpectError:    true,
+			ExpectedErrMsg: "fetching refund failed: The id provided does not exist",
+		},
+		{
+			Name:           "missing refund_id parameter",
+			Request:        map[string]interface{}{},
+			MockHttpClient: nil,
+			ExpectError:    true,
+			ExpectedErrMsg: "missing required parameter: refund_id",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			runToolTest(t, tc, FetchRefund, "Refund")
+		})
+	}
+}
+
+func Test_UpdateRefund(t *testing.T) {
+	updateRefundPathFmt := fmt.Sprintf(
+		"/%s%s/%%s",
+		constants.VERSION_V1,
+		constants.REFUND_URL,
+	)
+
+	// Define test response for successful refund update
+	successfulUpdateResp := map[string]interface{}{
+		"id":         "rfnd_DfjjhJC6eDvUAi",
+		"entity":     "refund",
+		"amount":     float64(300100),
+		"currency":   "INR",
+		"payment_id": "pay_FIKOnlyii5QGNx",
+		"notes": map[string]interface{}{
+			"notes_key_1": "Beam me up Scotty.",
+			"notes_key_2": "Engage",
+		},
+		"receipt":         nil,
+		"acquirer_data":   map[string]interface{}{"arn": "10000000000000"},
+		"created_at":      float64(1597078124),
+		"batch_id":        nil,
+		"status":          "processed",
+		"speed_processed": "normal",
+		"speed_requested": "optimum",
+	}
+
+	// Define error responses
+	notFoundResp := map[string]interface{}{
+		"error": map[string]interface{}{
+			"code":        "BAD_REQUEST_ERROR",
+			"description": "The id provided does not exist",
+		},
+	}
+
+	tests := []RazorpayToolTestCase{
+		{
+			Name: "successful refund update",
+			Request: map[string]interface{}{
+				"refund_id": "rfnd_DfjjhJC6eDvUAi",
+				"notes": map[string]interface{}{
+					"notes_key_1": "Beam me up Scotty.",
+					"notes_key_2": "Engage",
+				},
+			},
+			MockHttpClient: func() (*http.Client, *httptest.Server) {
+				return mock.NewHTTPClient(
+					mock.Endpoint{
+						Path:     fmt.Sprintf(updateRefundPathFmt, "rfnd_DfjjhJC6eDvUAi"),
+						Method:   "PATCH",
+						Response: successfulUpdateResp,
+					},
+				)
+			},
+			ExpectError:    false,
+			ExpectedResult: successfulUpdateResp,
+		},
+		{
+			Name: "refund id not found",
+			Request: map[string]interface{}{
+				"refund_id": "rfnd_nonexistent",
+				"notes": map[string]interface{}{
+					"note_key": "Test note",
+				},
+			},
+			MockHttpClient: func() (*http.Client, *httptest.Server) {
+				return mock.NewHTTPClient(
+					mock.Endpoint{
+						Path:     fmt.Sprintf(updateRefundPathFmt, "rfnd_nonexistent"),
+						Method:   "PATCH",
+						Response: notFoundResp,
+					},
+				)
+			},
+			ExpectError:    true,
+			ExpectedErrMsg: "updating refund failed: The id provided does not exist",
+		},
+		{
+			Name:           "missing refund_id parameter",
+			Request:        map[string]interface{}{},
+			MockHttpClient: nil,
+			ExpectError:    true,
+			ExpectedErrMsg: "missing required parameter: refund_id",
+		},
+		{
+			Name: "missing notes parameter",
+			Request: map[string]interface{}{
+				"refund_id": "rfnd_DfjjhJC6eDvUAi",
+			},
+			MockHttpClient: nil,
+			ExpectError:    true,
+			ExpectedErrMsg: "missing required parameter: notes",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			runToolTest(t, tc, UpdateRefund, "Refund")
+		})
+	}
+}

--- a/pkg/razorpay/tools.go
+++ b/pkg/razorpay/tools.go
@@ -41,10 +41,20 @@ func NewToolSets(
 			CreateOrder(log, client),
 		)
 
+	refunds := toolsets.NewToolset("refunds", "Razorpay Refunds related tools").
+		AddReadTools(
+			FetchRefund(log, client),
+		).
+		AddWriteTools(
+			CreateRefund(log, client),
+			UpdateRefund(log, client),
+		)
+
 	// Add toolsets to the group
 	toolsetGroup.AddToolset(payments)
 	toolsetGroup.AddToolset(paymentLinks)
 	toolsetGroup.AddToolset(orders)
+	toolsetGroup.AddToolset(refunds)
 
 	// Enable the requested features
 	if err := toolsetGroup.EnableToolsets(enabledToolsets); err != nil {


### PR DESCRIPTION
## Description
Add refund CRU APIs for razorpay MCP Server.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Testing
- [x] Manual testing
- [x] Added unit tests
- [x] All tests pass locally

## Checklist
- [x] I have followed the code style of this project
- [x] I have added comments to code where necessary, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary
- [x] I have verified that my changes do not introduce new warnings or errors
- [x] I have checked for and resolved any merge conflicts
- [x] I have considered the performance implications of my changes