### PR TITLE
feat: upgrade golangci-lint to v2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
           go mod verify
           go mod download
 
-          LINT_VERSION=1.64.8
+          LINT_VERSION=2.1.6
           curl -fsSL https://github.com/golangci/golangci-lint/releases/download/v${LINT_VERSION}/golangci-lint-${LINT_VERSION}-linux-amd64.tar.gz | \
             tar xz --strip-components 1 --wildcards \*/golangci-lint
           mkdir -p bin && mv golangci-lint bin/
@@ -45,6 +45,6 @@ jobs:
           assert-nothing-changed go fmt ./...
           assert-nothing-changed go mod tidy
 
-          bin/golangci-lint run --out-format=colored-line-number --timeout=3m || STATUS=$?
+          bin/golangci-lint run --timeout=3m || STATUS=$?
 
           exit $STATUS

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,27 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
         with:
-          go-version-file: "go.mod"
+          go-version-file: 'go.mod'
+
+      - name: Verify dependencies
+        run: |
+          go mod verify
+          go mod download
+
+      - name: Run checks
+        run: |
+          STATUS=0
+          assert-nothing-changed() {
+            local diff
+            "$@" >/dev/null || return 1
+            if ! diff="$(git diff -U1 --color --exit-code)"; then
+              printf '\e[31mError: running `\e[1m%s\e[22m` results in modifications that you must check into version control:\e[0m\n%s\n\n' "$*" "$diff" >&2
+              git checkout -- .
+              STATUS=1
+            fi
+          }
+          assert-nothing-changed go mod tidy
+          exit $STATUS
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,5 @@
 name: Lint
+
 on:
   push:
   pull_request:
@@ -17,34 +18,9 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
 
-      - name: Verify dependencies
-        run: |
-          go mod verify
-          go mod download
-
-          LINT_VERSION=2.1.6
-          curl -fsSL https://github.com/golangci/golangci-lint/releases/download/v${LINT_VERSION}/golangci-lint-${LINT_VERSION}-linux-amd64.tar.gz | \
-            tar xz --strip-components 1 --wildcards \*/golangci-lint
-          mkdir -p bin && mv golangci-lint bin/
-
-      - name: Run checks
-        run: |
-          STATUS=0
-          assert-nothing-changed() {
-            local diff
-            "$@" >/dev/null || return 1
-            if ! diff="$(git diff -U1 --color --exit-code)"; then
-              printf '\e[31mError: running `\e[1m%s\e[22m` results in modifications that you must check into version control:\e[0m\n%s\n\n' "$*" "$diff" >&2
-              git checkout -- .
-              STATUS=1
-            fi
-          }
-
-          assert-nothing-changed go fmt ./...
-          assert-nothing-changed go mod tidy
-
-          bin/golangci-lint run --timeout=3m || STATUS=$?
-
-          exit $STATUS
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9
+        with:
+          version: v2.1.6

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,3 +1,6 @@
+# https://golangci-lint.run/usage/configuration
+version: "2"
+
 run:
   timeout: 5m
   tests: true
@@ -7,17 +10,13 @@ linters:
   disable-all: true
   enable:
     - errcheck
-    - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - typecheck
     - unused
     - gocyclo
     - gosec
     - misspell
-    - gofmt
-    - goimports
     - revive
     - interfacebloat
     - iface
@@ -26,31 +25,35 @@ linters:
     - makezero
     - lll
 
-linters-settings:
-  gocyclo:
-    min-complexity: 15
-  dupl:
-    threshold: 100
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  goimports:
-    local-prefixes: github.com/razorpay/razorpay-mcp-server
-  interfacebloat:
-    max: 5
-  iface:
-    enable:
-      - opaque
-      - identical
-  revive:
-    rules:
-      - name: blank-imports
-        disabled: true
-  lll:
-    line-length: 80
-    tab-width: 1
+  settings:
+    dupl:
+      threshold: 100
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocyclo:
+      min-complexity: 15
+    interfacebloat:
+      max: 5
+    iface:
+      enable:
+        - opaque
+        - identical
+    lll:
+      line-length: 120
+      tab-width: 1
+    revive:
+      rules:
+        - name: blank-imports
+          disabled: true
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
 
 output:
-  formats: colored-line-number
-  print-issued-lines: true
-  print-linter-name: true
+  formats:
+    text:
+      print-linter-name: true
+      print-issued-lines: true

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ test-coverage:
 
 # Install golangci-lint
 install-lint:
-	@LINT_VERSION=1.64.8; \
+	@LINT_VERSION=2.1.6; \
 	if ! command -v golangci-lint > /dev/null 2>&1; then \
 		echo "Installing golangci-lint v$$LINT_VERSION..."; \
 		curl -fsSL https://github.com/golangci/golangci-lint/releases/download/v$$LINT_VERSION/golangci-lint-$$LINT_VERSION-$$($(GO) env GOOS)-$$($(GO) env GOARCH).tar.gz | \
@@ -68,7 +68,7 @@ lint: install-lint
 	@if [ -f ./bin/golangci-lint ]; then \
 		./bin/golangci-lint run --out-format=colored-line-number --timeout=3m; \
 	else \
-		golangci-lint run --out-format=colored-line-number --timeout=3m; \
+		golangci-lint run --timeout=3m; \
 	fi
 
 # Clean build artifacts

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -32,7 +32,7 @@ func New(path string) (*slog.Logger, func(), error) {
 		path = getDefaultLogPath()
 	}
 
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666) // nolint:gosec
 	if err != nil {
 		// Fall back to stderr if we can't open the log file
 		fmt.Fprintf(

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -37,15 +37,14 @@ func TestNew(t *testing.T) {
 		},
 	}
 
-	// nolint:all
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			defer func() {
 				if tt.path != "" {
-					os.Remove(tt.path)
+					_ = os.Remove(tt.path)
 				}
 				if tt.path == "" {
-					os.Remove(getDefaultLogPath())
+					_ = os.Remove(getDefaultLogPath())
 				}
 			}()
 

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -37,6 +37,7 @@ func TestNew(t *testing.T) {
 		},
 	}
 
+	// nolint:all
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			defer func() {

--- a/pkg/razorpay/mock/server_test.go
+++ b/pkg/razorpay/mock/server_test.go
@@ -25,7 +25,7 @@ func TestNewHTTPClient(t *testing.T) {
 
 	resp, err := client.Get(server.URL + "/test")
 	assert.NoError(t, err)
-	defer resp.Body.Close()
+	defer resp.Body.Close() // nolint:errcheck
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
@@ -143,7 +143,7 @@ func TestNewServer(t *testing.T) {
 			client := server.Client()
 			resp, err := client.Do(req)
 			assert.NoError(t, err)
-			defer resp.Body.Close()
+			defer resp.Body.Close() // nolint:errcheck
 
 			assert.Equal(t, tc.expectedStatus, resp.StatusCode)
 
@@ -204,14 +204,15 @@ func TestMultipleEndpoints(t *testing.T) {
 				err  error
 			)
 
-			if tc.method == "GET" {
+			switch tc.method {
+			case "GET":
 				resp, err = client.Get(server.URL + tc.path)
-			} else if tc.method == "POST" {
+			case "POST":
 				resp, err = client.Post(server.URL+tc.path,
 					"application/json", nil)
 			}
 			assert.NoError(t, err)
-			defer resp.Body.Close()
+			defer resp.Body.Close() // nolint:errcheck
 
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 

--- a/pkg/razorpay/mock/server_test.go
+++ b/pkg/razorpay/mock/server_test.go
@@ -25,7 +25,9 @@ func TestNewHTTPClient(t *testing.T) {
 
 	resp, err := client.Get(server.URL + "/test")
 	assert.NoError(t, err)
-	defer resp.Body.Close() // nolint:errcheck
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
@@ -143,7 +145,9 @@ func TestNewServer(t *testing.T) {
 			client := server.Client()
 			resp, err := client.Do(req)
 			assert.NoError(t, err)
-			defer resp.Body.Close() // nolint:errcheck
+			defer func() {
+				_ = resp.Body.Close()
+			}()
 
 			assert.Equal(t, tc.expectedStatus, resp.StatusCode)
 
@@ -212,7 +216,9 @@ func TestMultipleEndpoints(t *testing.T) {
 					"application/json", nil)
 			}
 			assert.NoError(t, err)
-			defer resp.Body.Close() // nolint:errcheck
+			defer func() {
+				_ = resp.Body.Close()
+			}()
 
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes introduced by this PR -->

## Related Issues
<!-- List any related issues that this PR addresses (e.g., "Fixes #123", "Resolves #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, code improvements only)
- [ ] Documentation update
- [ ] Performance improvement

## Testing
<!-- Describe the tests you've performed to verify your changes -->
- [ ] Manual testing
- [ ] Added unit tests
- [ ] Added integration tests (if applicable)
- [x] All tests pass locally

## Checklist
<!-- Please check all items that apply to this PR -->
- [x] I have followed the code style of this project
- [x] I have added comments to code where necessary, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary
- [ ] I have verified that my changes do not introduce new warnings or errors
- [x] I have checked for and resolved any merge conflicts
- [x] I have considered the performance implications of my changes

## Additional Information
<!-- Add any additional context, screenshots, or information that might be helpful for reviewers --> 

This upgrade the `golangci-lint` from v1 to v2 and migrates the `.golangci.yaml`. This is derived from [my contribution](https://github.com/github/github-mcp-server/pull/386) to the [github-mcp-server](https://github.com/github/github-mcp-server) which does the same thing.

While upgrading the `golangci-lint` to v2, I noticed there are a few warnings produced by the `errcheck` and other linters from the test files. I have ignored the warnings for now and would love to hear some feedback..