### PR TITLE
feat: add optional CVV field to InitiatePayment tool

### DIFF
--- a/pkg/razorpay/payments_test.go
+++ b/pkg/razorpay/payments_test.go
@@ -675,6 +675,78 @@ func Test_InitiatePayment(t *testing.T) {
 			},
 		},
 		{
+			Name: "successful payment initiation with CVV",
+			Request: map[string]interface{}{
+				"amount":   10000,
+				"currency": "INR",
+				"token":    "token_MT48CvBhIC98MQ",
+				"order_id": "order_MT48CvBhIC98MQ",
+				"email":    "test@example.com",
+				"contact":  "9876543210",
+				"cvv":      "123",
+			},
+			MockHttpClient: func() (*http.Client, *httptest.Server) {
+				return mock.NewHTTPClient(
+					mock.Endpoint{
+						Path:     initiatePaymentPath,
+						Method:   "POST",
+						Response: successPaymentWithoutNextResp,
+					},
+				)
+			},
+			ExpectError: false,
+			ExpectedResult: map[string]interface{}{
+				"razorpay_payment_id": "pay_MT48CvBhIC98MQ",
+				"payment_details":     successPaymentWithoutNextResp,
+				"status":              "payment_initiated",
+				"message": "Payment initiated successfully using " +
+					"S2S JSON v1 flow",
+				"next_step": "Use 'resend_otp' to regenerate OTP or " +
+					"'submit_otp' to proceed to enter OTP if " +
+					"OTP authentication is required.",
+				"next_tool": "resend_otp",
+				"next_tool_params": map[string]interface{}{
+					"payment_id": "pay_MT48CvBhIC98MQ",
+				},
+			},
+		},
+		{
+			Name: "successful payment initiation without CVV (empty string)",
+			Request: map[string]interface{}{
+				"amount":   10000,
+				"currency": "INR",
+				"token":    "token_MT48CvBhIC98MQ",
+				"order_id": "order_MT48CvBhIC98MQ",
+				"email":    "test@example.com",
+				"contact":  "9876543210",
+				"cvv":      "",
+			},
+			MockHttpClient: func() (*http.Client, *httptest.Server) {
+				return mock.NewHTTPClient(
+					mock.Endpoint{
+						Path:     initiatePaymentPath,
+						Method:   "POST",
+						Response: successPaymentWithoutNextResp,
+					},
+				)
+			},
+			ExpectError: false,
+			ExpectedResult: map[string]interface{}{
+				"razorpay_payment_id": "pay_MT48CvBhIC98MQ",
+				"payment_details":     successPaymentWithoutNextResp,
+				"status":              "payment_initiated",
+				"message": "Payment initiated successfully using " +
+					"S2S JSON v1 flow",
+				"next_step": "Use 'resend_otp' to regenerate OTP or " +
+					"'submit_otp' to proceed to enter OTP if " +
+					"OTP authentication is required.",
+				"next_tool": "resend_otp",
+				"next_tool_params": map[string]interface{}{
+					"payment_id": "pay_MT48CvBhIC98MQ",
+				},
+			},
+		},
+		{
 			Name: "successful payment initiation with redirect",
 			Request: map[string]interface{}{
 				"amount":   10000,


### PR DESCRIPTION
## Description

This PR adds an optional CVV field to the InitiatePayment tool, allowing users to provide CVV when initiating payments with saved cards/tokens. The CVV field is passed in the proper Razorpay S2S format within a 'card' object structure.

**Key Changes:**
- Added optional  parameter to InitiatePayment tool
- Updated parameter validation to handle optional CVV
- Modified payment data construction to include CVV in S2S format when provided
- Added comprehensive test coverage for CVV scenarios
- Maintained full backward compatibility

## Related Issues

No specific issue, this is an enhancement to support optional CVV in payment initiation.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, code improvements only)
- [ ] Documentation update
- [ ] Performance improvement

## Testing

- [x] Manual testing
- [x] Added unit tests
- [ ] Added integration tests (if applicable)
- [x] All tests pass locally

**Test Coverage:**
- Test case with CVV provided
- Test case with empty CVV (should not be included in payment data)
- All existing tests continue to pass

## Checklist

- [x] I have followed the code style of this project
- [x] I have added comments to code where necessary, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary
- [x] I have verified that my changes do not introduce new warnings or errors
- [x] I have checked for and resolved any merge conflicts
- [x] I have considered the performance implications of my changes

## Additional Information

- **CVV Format**: CVV is passed in the proper Razorpay S2S JSON format within a 'card' object
- **Backward Compatibility**: Fully backward compatible - existing implementations will work unchanged
- **Optional Nature**: CVV field is completely optional and follows Razorpay's CVV-less flow guidelines
- **Security**: No sensitive data logging or exposure concerns
- **Testing**: Comprehensive unit test coverage including edge cases