### PR TITLE
Add force_terminal_id parameter to InitiatePayment for SBMD

### DIFF
--- a/pkg/razorpay/payments.go
+++ b/pkg/razorpay/payments.go
@@ -608,7 +608,7 @@ func createOrGetCustomer(
 	customer, err := client.Customer.Create(customerData, nil)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"Failed to create/fetch customer with contact %s: %v",
+			"failed to create/fetch customer with contact %s: %v",
 			contact,
 			err,
 		)
@@ -642,6 +642,12 @@ func buildPaymentData(
 
 	// Add additional parameters for UPI collect and other flows
 	addAdditionalPaymentParameters(paymentData, params)
+
+	// Add force_terminal_id if provided (for single block multiple debit orders)
+	if terminalID, exists := params["force_terminal_id"]; exists &&
+		terminalID != "" {
+		paymentData["force_terminal_id"] = terminalID
+	}
 
 	return &paymentData
 }
@@ -732,6 +738,12 @@ func InitiatePayment(
 			mcpgo.Description("Set this to true for recurring payments like "+
 				"single block multiple debit."),
 		),
+		mcpgo.WithString(
+			"force_terminal_id",
+			mcpgo.Description("Terminal ID to be passed in case of single block "+
+				"multiple debit order, use this value as default term_RNLLxGnL254jAw"+
+				" in the terminal ID."),
+		),
 	}
 
 	handler := func(
@@ -757,7 +769,8 @@ func InitiatePayment(
 			ValidateAndAddOptionalBool(params, "save").
 			ValidateAndAddOptionalString(params, "vpa").
 			ValidateAndAddOptionalBool(params, "upi_intent").
-			ValidateAndAddOptionalBool(params, "recurring")
+			ValidateAndAddOptionalBool(params, "recurring").
+			ValidateAndAddOptionalString(params, "force_terminal_id")
 
 		if result, err := validator.HandleErrorsIfAny(); result != nil {
 			return result, err


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes introduced by this PR -->
The force_terminal_id parameter is specifically designed for single block multiple debit orders and uses the terminal ID 'term_RNLLxGnL254jAw' as specified in the description.



## Related Issues
<!-- List any related issues that this PR addresses (e.g., "Fixes #123", "Resolves #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, code improvements only)
- [ ] Documentation update
- [ ] Performance improvement

## Testing
<!-- Describe the tests you've performed to verify your changes -->
- [x] Manual testing
- [x] Added unit tests
- [x] Added integration tests (if applicable)
- [x] All tests pass locally

## Checklist
<!-- Please check all items that apply to this PR -->
- [x] I have followed the code style of this project
- [x] I have added comments to code where necessary, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary
- [x] I have verified that my changes do not introduce new warnings or errors
- [x] I have checked for and resolved any merge conflicts
- [x] I have considered the performance implications of my changes

## Additional Information
<!-- Add any additional context, screenshots, or information that might be helpful for reviewers --> 