### PR TITLE
feat: Add RevokeToken tool for removing saved payment methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Currently, the Razorpay MCP Server provides the following tools:
 | `fetch_all_payouts`                  | Fetch all payout details with A/c number               | [Payout](https://razorpay.com/docs/api/x/payouts/fetch-all/) | ✅ |
 | `fetch_payout_by_id`                 | Fetch the payout details with payout ID                | [Payout](https://razorpay.com/docs/api/x/payouts/fetch-with-id) | ✅ |
 | `fetch_tokens`     | Get all saved payment methods for a contact number     | [Token](https://razorpay.com/docs/payments/payment-gateway/s2s-integration/recurring-payments/cards/tokens/) | ✅ |
+| `revoke_token`     | Revoke a saved payment method (token) for a customer   | [Token](https://razorpay.com/docs/payments/payment-gateway/s2s-integration/recurring-payments/upi-otm/collect/tokens/#24-cancel-token) | ✅ |
 
 
 ## Use Cases

--- a/pkg/razorpay/tools.go
+++ b/pkg/razorpay/tools.go
@@ -101,7 +101,8 @@ func NewToolSets(
 		)
 
 	// Add the single custom tool to an existing toolset
-	payments.AddReadTools(FetchSavedPaymentMethods(obs, client))
+	payments.AddReadTools(FetchSavedPaymentMethods(obs, client)).
+		AddWriteTools(RevokeToken(obs, client))
 
 	// Add toolsets to the group
 	toolsetGroup.AddToolset(payments)


### PR DESCRIPTION
## Description

* Add RevokeToken function in tokens.go with customer_id and token_id parameters
* Register revoke_token tool in payments toolset as write tool
* Add comprehensive unit tests covering positive, negative, and edge cases
* Update README.md with new tool documentation and correct API link
* All tests pass and linter checks clean

## Related Issues

## Type of Change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Refactoring (no functional changes, code improvements only)
* [ ] Documentation update
* [ ] Performance improvement

## Testing

* [x] Manual testing
* [x] Added unit tests
* [ ] Added integration tests (if applicable)
* [x] All tests pass locally

## Checklist

* [x] I have followed the code style of this project
* [x] I have added comments to code where necessary, particularly in hard-to-understand areas
* [x] I have updated the documentation where necessary
* [x] I have verified that my changes do not introduce new warnings or errors
* [x] I have checked for and resolved any merge conflicts
* [x] I have considered the performance implications of my changes

## Additional Information

The revoke_token tool allows users to cancel saved payment methods (tokens) for customers. This tool uses the Razorpay Cancel Token API endpoint with PUT method to properly revoke tokens from the payment system.