### PR TITLE
chore: migrate docker build steps to razorpay/actions/docker-image-build-push@master

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,15 +16,6 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.PUBLIC_DOCKER_USERNAME }}
-          password: ${{ secrets.PUBLIC_DOCKER_PASSWORD }}
-
       - name: Get Build Info
         id: build_info
         run: |
@@ -48,12 +39,17 @@ jobs:
           fi
       
       - name: Build & Push
-        uses: docker/build-push-action@v6
+        uses: razorpay/actions/docker-image-build-push@master
         with:
+          username: ${{ secrets.HARBOR_DOCKER_USERNAME }}
+          password: ${{ secrets.HARBOR_DOCKER_PASSWORD }}
+          registry: c.rzp.io
+          repository: ${{ github.event.repository.name }}
+          custom-tag: ${{ steps.vars.outputs.tags }}
+          enable-login: true
           context: .
-          platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ steps.vars.outputs.tags }}
+          platforms: linux/amd64,linux/arm64
           build-args: |
             VERSION=${{ github.ref_name }}
             COMMIT=${{ steps.build_info.outputs.trigger_sha }}


### PR DESCRIPTION
## Summary
- Migrated all Docker build steps to use `razorpay/actions/docker-image-build-push@master`
- Replaced `docker/build-push-action`, `docker buildx build`, and/or `int128/docker-manifest-create-action` with the centralized composite action
- Converted any prefix/suffix usage to custom-tag approach
- Ensures consistent tagging, registry login, secret handling, multi-arch manifest creation, and automatic Harbor labeling

## Changes
- Updated `.github/workflows/` files to use the new action
- Added standard Harbor credentials and registry configuration
- Converted image tags to `custom-tag` format

## Test plan
- [ ] Verify workflow YAML syntax is valid
- [ ] Confirm all Docker build steps use `razorpay/actions/docker-image-build-push@master`
- [ ] Verify no remaining instances of old Docker build patterns
- [ ] Test a workflow run to confirm builds succeed

Generated with Claude Code docker-action-migrate skill