### PR TITLE
fix: clarify base64 example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,9 +194,11 @@ The Remote MCP Server uses merchant token-based authentication. To generate your
 
 3. Generate your merchant token by running this command in your terminal:
    ```bash
-   echo <RAZORPAY_API_KEY>:<RAZORPAY_API_SECRET> | base64
+   echo -n '<RAZORPAY_API_KEY>:<RAZORPAY_API_SECRET>' | base64
    ```
    Replace `<RAZORPAY_API_KEY>` and `<RAZORPAY_API_SECRET>` with your actual credentials
+
+   > Note: The `-n` flag prevents `echo` from adding a trailing newline, which would otherwise be included in the Base64 output and can cause `Authorization: Basic ...` to fail.
 
 4. Copy the base64-encoded output - this is your merchant token for the Remote MCP Server
 


### PR DESCRIPTION
## Description
This PR updates the README’s base64 example in the “Remote MCP Server (recommended)” section.

## Related Issues
<!-- List any related issues that this PR addresses (e.g., "Fixes #123", "Resolves #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, code improvements only)
- [x] Documentation update
- [ ] Performance improvement

## Testing
<!-- Describe the tests you've performed to verify your changes -->
- [x] Manual testing
  - Verified that the new command produces a Base64 string that decodes exactly to <RAZORPAY_API_KEY>:<RAZORPAY_API_SECRET> with no trailing newline.
  - Confirmed that using this value in Authorization: Basic ... works with the Remote MCP Server in test mode.
- [ ] Added unit tests
- [ ] Added integration tests (if applicable)
- [ ] All tests pass locally

## Checklist
<!-- Please check all items that apply to this PR -->
- [x] I have followed the code style of this project
- [x] I have added comments to code where necessary, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary
- [x] I have verified that my changes do not introduce new warnings or errors
- [x] I have checked for and resolved any merge conflicts
- [x] I have considered the performance implications of my changes

## Additional Information
<!-- Add any additional context, screenshots, or information that might be helpful for reviewers --> 
This is a minimal documentation change intended to make the Remote MCP Server setup more reliable for users who are new to Base64 encoding in the shell.