### PR TITLE
feat: added customer_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Currently, the Razorpay MCP Server provides the following tools:
 | `fetch_instant_settlement_with_id`   | Fetch instant settlement with ID                       | [Settlement](https://razorpay.com/docs/api/settlements/instant/fetch-with-id) | ✅ |
 | `fetch_all_payouts`                  | Fetch all payout details with A/c number               | [Payout](https://razorpay.com/docs/api/x/payouts/fetch-all/) | ✅ |
 | `fetch_payout_by_id`                 | Fetch the payout details with payout ID                | [Payout](https://razorpay.com/docs/api/x/payouts/fetch-with-id) | ✅ |
-| `fetch_tokens`     | Get all saved payment methods for a contact number     | [Token](https://razorpay.com/docs/payments/payment-gateway/s2s-integration/recurring-payments/cards/tokens/) | ✅ |
+| `fetch_tokens`     | Get all saved payment methods by customer ID or contact number | [Token](https://razorpay.com/docs/payments/payment-gateway/s2s-integration/recurring-payments/cards/tokens/) | ✅ |
 | `revoke_token`     | Revoke a saved payment method (token) for a customer   | [Token](https://razorpay.com/docs/payments/payment-gateway/s2s-integration/recurring-payments/upi-otm/collect/tokens/#24-cancel-token) | ✅ |
 | `detect_stack` | Detect project language/framework for checkout integration | N/A (MCP Integration Helper) | ✅ |
 | `integrate_razorpay_checkout` | Generate end-to-end Razorpay Standard Checkout integration code for supported frameworks | N/A (MCP Integration Helper) | ✅ |

--- a/README.md
+++ b/README.md
@@ -403,3 +403,4 @@ You can use the standard Go debugging tools to troubleshoot issues with the serv
 ## License
 
 This project is licensed under the terms of the MIT open source license. Please refer to [LICENSE](./LICENSE) for the full terms.
+

--- a/pkg/razorpay/tokens.go
+++ b/pkg/razorpay/tokens.go
@@ -12,18 +12,28 @@ import (
 )
 
 // FetchSavedPaymentMethods returns a tool that fetches saved cards
-// using contact number
+// using a customer_id or contact number.
+// When customer_id is provided it is used directly; otherwise
+// the contact number is used to create/find the customer first.
 func FetchSavedPaymentMethods(
 	obs *observability.Observability,
 	client *rzpsdk.Client,
 ) mcpgo.Tool {
 	parameters := []mcpgo.ToolParameter{
 		mcpgo.WithString(
+			"customer_id",
+			mcpgo.Description(
+				"Razorpay customer ID to fetch saved payment methods for. "+
+					"Must start with 'cust_' followed by alphanumeric characters. "+
+					"Example: 'cust_xxx'. "+
+					"When provided, this takes priority over the contact parameter."),
+		),
+		mcpgo.WithString(
 			"contact",
 			mcpgo.Description(
 				"Contact number of the customer to fetch all saved payment methods for. "+
-					"For example, 9876543210 or +919876543210"),
-			mcpgo.Required(),
+					"For example, 9876543210 or +919876543210. "+
+					"Used only when customer_id is not provided."),
 		),
 	}
 
@@ -31,7 +41,6 @@ func FetchSavedPaymentMethods(
 		ctx context.Context,
 		r mcpgo.CallToolRequest,
 	) (*mcpgo.ToolResult, error) {
-		// Get client from context or use default
 		client, err := getClientFromContextOrDefault(ctx, client)
 		if err != nil {
 			return mcpgo.NewToolResultError(err.Error()), nil
@@ -39,41 +48,68 @@ func FetchSavedPaymentMethods(
 
 		validator := NewValidator(&r)
 
-		// Validate required contact parameter
-		contactValue, err := extractValueGeneric[string](&r, "contact", true)
-		if err != nil {
-			validator = validator.addError(err)
-		} else if contactValue == nil || *contactValue == "" {
+		customerIDValue, _ := extractValueGeneric[string](
+			&r, "customer_id", false)
+		contactValue, _ := extractValueGeneric[string](
+			&r, "contact", false)
+
+		hasCustomerID := customerIDValue != nil && *customerIDValue != ""
+		hasContact := contactValue != nil && *contactValue != ""
+
+		if !hasCustomerID && !hasContact {
 			validator = validator.addError(
-				fmt.Errorf("missing required parameter: contact"))
+				fmt.Errorf(
+					"either customer_id or contact must be provided"))
 		}
 		if result, err := validator.HandleErrorsIfAny(); result != nil {
 			return result, err
 		}
-		contact := *contactValue
-		customerData := map[string]interface{}{
-			"contact":       contact,
-			"fail_existing": "0", // Get existing customer if exists
-		}
 
-		// Create/get customer using Razorpay SDK
-		customer, err := client.Customer.Create(customerData, nil)
-		if err != nil {
-			return mcpgo.NewToolResultError(
-				fmt.Sprintf(
-					"Failed to create/fetch customer with contact %s: %v", contact, err,
-				)), nil
-		}
+		var customerID string
+		var customer map[string]interface{}
 
-		customerID, ok := customer["id"].(string)
-		if !ok {
-			return mcpgo.NewToolResultError("Customer ID not found in response"), nil
+		if hasCustomerID {
+			customerID = *customerIDValue
+
+			url := fmt.Sprintf("/%s%s/%s",
+				constants.VERSION_V1,
+				constants.CUSTOMER_URL,
+				customerID)
+			customer, err = client.Request.Get(url, nil, nil)
+			if err != nil {
+				return mcpgo.NewToolResultError(
+					fmt.Sprintf(
+						"Failed to fetch customer %s: %v",
+						customerID, err,
+					)), nil
+			}
+		} else {
+			contact := *contactValue
+			customerData := map[string]interface{}{
+				"contact":       contact,
+				"fail_existing": "0",
+			}
+
+			customer, err = client.Customer.Create(customerData, nil)
+			if err != nil {
+				return mcpgo.NewToolResultError(
+					fmt.Sprintf(
+						"Failed to create/fetch customer with contact %s: %v",
+						contact, err,
+					)), nil
+			}
+
+			id, ok := customer["id"].(string)
+			if !ok {
+				return mcpgo.NewToolResultError(
+					"Customer ID not found in response"), nil
+			}
+			customerID = id
 		}
 
 		url := fmt.Sprintf("/%s/customers/%s/tokens",
 			constants.VERSION_V1, customerID)
 
-		// Make the API request to get tokens
 		tokensResponse, err := client.Request.Get(url, nil, nil)
 		if err != nil {
 			return mcpgo.NewToolResultError(
@@ -93,14 +129,16 @@ func FetchSavedPaymentMethods(
 
 	return mcpgo.NewTool(
 		"fetch_tokens",
-		"Get all saved payment methods (cards, UPI)"+
-			" for a contact number. "+
-			"This tool first finds or creates a"+
-			" customer with the given contact number, "+
-			"then fetches all saved payment tokens "+
-			"associated with that customer including "+
-			"credit/debit cards, UPI IDs, digital wallets,"+
-			" and other tokenized payment instruments.",
+		"Get all saved payment methods (cards, UPI) "+
+			"for a customer. Accepts either a customer_id "+
+			"(preferred) or a contact number. "+
+			"When customer_id is provided it is used "+
+			"directly to fetch tokens; otherwise the "+
+			"contact number is used to find or create "+
+			"the customer first. Returns saved payment "+
+			"tokens including credit/debit cards, UPI IDs,"+
+			" digital wallets, and other tokenized "+
+			"payment instruments.",
 		parameters,
 		handler,
 	)

--- a/pkg/razorpay/tokens_test.go
+++ b/pkg/razorpay/tokens_test.go
@@ -23,6 +23,12 @@ func Test_FetchSavedPaymentMethods(t *testing.T) {
 		constants.CUSTOMER_URL,
 	)
 
+	fetchCustomerPathFmt := fmt.Sprintf(
+		"/%s%s/%%s",
+		constants.VERSION_V1,
+		constants.CUSTOMER_URL,
+	)
+
 	fetchTokensPathFmt := fmt.Sprintf(
 		"/%s/customers/%%s/tokens",
 		constants.VERSION_V1,
@@ -125,6 +131,13 @@ func Test_FetchSavedPaymentMethods(t *testing.T) {
 		},
 	}
 
+	customerNotFoundResp := map[string]interface{}{
+		"error": map[string]interface{}{
+			"code":        "BAD_REQUEST_ERROR",
+			"description": "Customer not found",
+		},
+	}
+
 	// Customer response without ID (invalid)
 	invalidCustomerResp := map[string]interface{}{
 		"entity":     "customer",
@@ -134,10 +147,10 @@ func Test_FetchSavedPaymentMethods(t *testing.T) {
 		"gstin":      nil,
 		"notes":      map[string]interface{}{},
 		"created_at": float64(1234567890),
-		// Missing "id" field
 	}
 
 	tests := []RazorpayToolTestCase{
+		// --- contact-based tests (existing behaviour) ---
 		{
 			Name: "successful fetch of saved cards with valid contact",
 			Request: map[string]interface{}{
@@ -151,7 +164,8 @@ func Test_FetchSavedPaymentMethods(t *testing.T) {
 						Response: customerResp,
 					},
 					mock.Endpoint{
-						Path:     fmt.Sprintf(fetchTokensPathFmt, "cust_1Aa00000000003"),
+						Path: fmt.Sprintf(
+							fetchTokensPathFmt, "cust_1Aa00000000003"),
 						Method:   "GET",
 						Response: tokensResp,
 					},
@@ -183,7 +197,8 @@ func Test_FetchSavedPaymentMethods(t *testing.T) {
 						Response: customerRespIntl,
 					},
 					mock.Endpoint{
-						Path:     fmt.Sprintf(fetchTokensPathFmt, "cust_1Aa00000000004"),
+						Path: fmt.Sprintf(
+							fetchTokensPathFmt, "cust_1Aa00000000004"),
 						Method:   "GET",
 						Response: tokensResp,
 					},
@@ -235,7 +250,8 @@ func Test_FetchSavedPaymentMethods(t *testing.T) {
 						Response: customerResp,
 					},
 					mock.Endpoint{
-						Path:     fmt.Sprintf(fetchTokensPathFmt, "cust_1Aa00000000003"),
+						Path: fmt.Sprintf(
+							fetchTokensPathFmt, "cust_1Aa00000000003"),
 						Method:   "GET",
 						Response: tokensAPIFailedResp,
 					},
@@ -263,33 +279,6 @@ func Test_FetchSavedPaymentMethods(t *testing.T) {
 			ExpectedErrMsg: "Customer ID not found in response",
 		},
 		{
-			Name:    "missing contact parameter",
-			Request: map[string]interface{}{
-				// No contact parameter
-			},
-			MockHttpClient: nil, // No HTTP client needed for validation error
-			ExpectError:    true,
-			ExpectedErrMsg: "missing required parameter: contact",
-		},
-		{
-			Name: "empty contact parameter",
-			Request: map[string]interface{}{
-				"contact": "",
-			},
-			MockHttpClient: nil, // No HTTP client needed for validation error
-			ExpectError:    true,
-			ExpectedErrMsg: "missing required parameter: contact",
-		},
-		{
-			Name: "null contact parameter",
-			Request: map[string]interface{}{
-				"contact": nil,
-			},
-			MockHttpClient: nil, // No HTTP client needed for validation error
-			ExpectError:    true,
-			ExpectedErrMsg: "missing required parameter: contact",
-		},
-		{
 			Name: "successful fetch with empty tokens list",
 			Request: map[string]interface{}{
 				"contact": "9876543210",
@@ -307,7 +296,8 @@ func Test_FetchSavedPaymentMethods(t *testing.T) {
 						Response: customerResp,
 					},
 					mock.Endpoint{
-						Path:     fmt.Sprintf(fetchTokensPathFmt, "cust_1Aa00000000003"),
+						Path: fmt.Sprintf(
+							fetchTokensPathFmt, "cust_1Aa00000000003"),
 						Method:   "GET",
 						Response: emptyTokensResp,
 					},
@@ -322,6 +312,144 @@ func Test_FetchSavedPaymentMethods(t *testing.T) {
 					"items":  []interface{}{},
 				},
 			},
+		},
+		// --- customer_id-based tests (new behaviour) ---
+		{
+			Name: "successful fetch with customer_id",
+			Request: map[string]interface{}{
+				"customer_id": "cust_1Aa00000000003",
+			},
+			MockHttpClient: func() (*http.Client, *httptest.Server) {
+				return mock.NewHTTPClient(
+					mock.Endpoint{
+						Path: fmt.Sprintf(
+							fetchCustomerPathFmt, "cust_1Aa00000000003"),
+						Method:   "GET",
+						Response: customerResp,
+					},
+					mock.Endpoint{
+						Path: fmt.Sprintf(
+							fetchTokensPathFmt, "cust_1Aa00000000003"),
+						Method:   "GET",
+						Response: tokensResp,
+					},
+				)
+			},
+			ExpectError:    false,
+			ExpectedResult: expectedSuccessResp,
+		},
+		{
+			Name: "customer_id takes priority over contact",
+			Request: map[string]interface{}{
+				"customer_id": "cust_1Aa00000000003",
+				"contact":     "9876543210",
+			},
+			MockHttpClient: func() (*http.Client, *httptest.Server) {
+				return mock.NewHTTPClient(
+					mock.Endpoint{
+						Path: fmt.Sprintf(
+							fetchCustomerPathFmt, "cust_1Aa00000000003"),
+						Method:   "GET",
+						Response: customerResp,
+					},
+					mock.Endpoint{
+						Path: fmt.Sprintf(
+							fetchTokensPathFmt, "cust_1Aa00000000003"),
+						Method:   "GET",
+						Response: tokensResp,
+					},
+				)
+			},
+			ExpectError:    false,
+			ExpectedResult: expectedSuccessResp,
+		},
+		{
+			Name: "customer_id fetch failure",
+			Request: map[string]interface{}{
+				"customer_id": "cust_nonexistent",
+			},
+			MockHttpClient: func() (*http.Client, *httptest.Server) {
+				return mock.NewHTTPClient(
+					mock.Endpoint{
+						Path: fmt.Sprintf(
+							fetchCustomerPathFmt, "cust_nonexistent"),
+						Method:   "GET",
+						Response: customerNotFoundResp,
+					},
+				)
+			},
+			ExpectError: true,
+			ExpectedErrMsg: "Failed to fetch customer cust_nonexistent: " +
+				"Customer not found",
+		},
+		{
+			Name: "tokens API failure after successful customer_id fetch", //nolint:lll
+			Request: map[string]interface{}{
+				"customer_id": "cust_1Aa00000000003",
+			},
+			MockHttpClient: func() (*http.Client, *httptest.Server) {
+				return mock.NewHTTPClient(
+					mock.Endpoint{
+						Path: fmt.Sprintf(
+							fetchCustomerPathFmt, "cust_1Aa00000000003"),
+						Method:   "GET",
+						Response: customerResp,
+					},
+					mock.Endpoint{
+						Path: fmt.Sprintf(
+							fetchTokensPathFmt, "cust_1Aa00000000003"),
+						Method:   "GET",
+						Response: tokensAPIFailedResp,
+					},
+				)
+			},
+			ExpectError: true,
+			ExpectedErrMsg: "Failed to fetch saved payment methods for " +
+				"customer cust_1Aa00000000003: Customer not found",
+		},
+		// --- validation error tests ---
+		{
+			Name:           "neither customer_id nor contact provided",
+			Request:        map[string]interface{}{},
+			MockHttpClient: nil,
+			ExpectError:    true,
+			ExpectedErrMsg: "either customer_id or contact must be provided",
+		},
+		{
+			Name: "empty contact parameter",
+			Request: map[string]interface{}{
+				"contact": "",
+			},
+			MockHttpClient: nil,
+			ExpectError:    true,
+			ExpectedErrMsg: "either customer_id or contact must be provided",
+		},
+		{
+			Name: "null contact parameter",
+			Request: map[string]interface{}{
+				"contact": nil,
+			},
+			MockHttpClient: nil,
+			ExpectError:    true,
+			ExpectedErrMsg: "either customer_id or contact must be provided",
+		},
+		{
+			Name: "empty customer_id parameter",
+			Request: map[string]interface{}{
+				"customer_id": "",
+			},
+			MockHttpClient: nil,
+			ExpectError:    true,
+			ExpectedErrMsg: "either customer_id or contact must be provided",
+		},
+		{
+			Name: "null customer_id parameter",
+			Request: map[string]interface{}{
+				"customer_id": nil,
+			},
+			MockHttpClient: nil,
+			ExpectError:    true,
+			ExpectedErrMsg: "either customer_id or contact must be provided",
 		},
 	}
 


### PR DESCRIPTION
## Description
Added `customer_id` as an optional parameter to the `fetch_tokens` tool. When `customer_id` is provided, it is used directly to fetch the customer and their tokens via a GET request, skipping the customer creation/lookup step. When only `contact` is provided, the existing behaviour is preserved (create/find customer, then fetch tokens). At least one of `customer_id` or `contact` must be supplied. `customer_id` takes priority when both are provided.

## Related Issues
<!-- List any related issues that this PR addresses (e.g., "Fixes #123", "Resolves #456") -->

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, code improvements only)
- [ ] Documentation update
- [ ] Performance improvement

## Testing
- [x] Manual testing
- [x] Added unit tests
- [ ] Added integration tests (if applicable)
- [x] All tests pass locally

## Checklist
- [x] I have followed the code style of this project
- [x] I have added comments to code where necessary, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary
- [x] I have verified that my changes do not introduce new warnings or errors
- [x] I have checked for and resolved any merge conflicts
- [x] I have considered the performance implications of my changes

## Additional Information
### Changes
- **`pkg/razorpay/tokens.go`** — Added `customer_id` parameter, updated validation to require at least one of `customer_id` or `contact`, and branched the handler logic to either fetch the customer by ID or create/find by contact.
- **`pkg/razorpay/tokens_test.go`** — Added test cases for `customer_id`-based fetch (success, priority over contact, customer not found, tokens API failure) and updated validation error tests to reflect the new "either/or" requirement.
- **`README.md`** — Updated `fetch_tokens` tool description to reflect that it now accepts a customer ID or contact number.