### PR TITLE
feat: add create_subscription_registration_auth_link tool

### DIFF
--- a/.agents/skills/razorpay-mcp-tool-gen/SKILL.md
+++ b/.agents/skills/razorpay-mcp-tool-gen/SKILL.md
@@ -1,0 +1,350 @@
+---
+name: razorpay-mcp-tool-gen
+description: >-
+  Generate Razorpay MCP server tool implementations from API documentation URLs,
+  curl commands, or request/response examples. Produces Go tool code, unit tests,
+  registration, and README updates. Use when the user provides a Razorpay API doc
+  link, curl example, or request/response payload and wants a new MCP tool created.
+---
+
+# Razorpay MCP Tool Generator
+
+Generate complete MCP tool implementations from Razorpay API docs, curl commands, or request/response examples.
+
+## Input Formats
+
+The user may provide any of:
+
+1. **Razorpay docs URL** — `https://razorpay.com/docs/api/...`
+2. **curl command** — extract method, path, headers, body, and response
+3. **Request/response JSON** — raw payload and expected response
+4. **SDK function signature** — Go SDK function to call
+
+If the **tool name** is not provided or cannot be inferred, **ask the user** before proceeding.
+
+## Workflow
+
+```
+Task Progress:
+- [ ] Step 1: Parse input and extract API contract
+- [ ] Step 2: Determine tool name and resource file
+- [ ] Step 3: Implement tool function
+- [ ] Step 4: Register tool in tools.go
+- [ ] Step 5: Write unit tests
+- [ ] Step 6: Update README.md Available Tools table
+- [ ] Step 7: Run linter — fix errors
+- [ ] Step 8: Run tests — fix errors
+- [ ] Step 9: Create branch, commit, and open PR (if gh available)
+```
+
+### Step 1: Parse Input
+
+**From docs URL**: Fetch the page and extract endpoint path, HTTP method, required/optional params with types and descriptions, and example response.
+
+**From curl**: Parse the method (`-X`), URL path, headers (`-H`), request body (`-d`), and note the response if provided.
+
+**From request/response JSON**: Infer required vs optional fields, types, and construct parameter definitions.
+
+Map each parameter to a validator type:
+
+| JSON type | Parameter helper | Validator method |
+|-----------|-----------------|------------------|
+| string | `mcpgo.WithString` | `ValidateAndAddRequiredString` / `ValidateAndAddOptionalString` |
+| number (int) | `mcpgo.WithNumber` | `ValidateAndAddRequiredInt` / `ValidateAndAddOptionalInt` |
+| number (float) | `mcpgo.WithNumber` | `ValidateAndAddRequiredFloat` / `ValidateAndAddOptionalFloat` |
+| boolean | `mcpgo.WithBoolean` | `ValidateAndAddRequiredBool` / `ValidateAndAddOptionalBool` |
+| object | `mcpgo.WithObject` | `ValidateAndAddRequiredMap` / `ValidateAndAddOptionalMap` |
+| array | `mcpgo.WithArray` | `ValidateAndAddRequiredArray` / `ValidateAndAddOptionalArray` |
+
+For nested objects (e.g., `customer.name` flattened to `customer_name`), use `ValidateAndAddOptionalStringToPath`.
+
+### Step 2: Determine Tool Name and File
+
+Naming conventions:
+- Fetch single: `fetch_{resource}` → `Fetch{Resource}`
+- Fetch list: `fetch_all_{resources}` → `FetchAll{Resources}`
+- Create: `create_{resource}` → `Create{Resource}`
+- Update: `update_{resource}` → `Update{Resource}`
+
+Place the tool in `pkg/razorpay/{resource_type}.go`. Create a new file only if the resource type doesn't already exist.
+
+### Step 3: Implement Tool
+
+Follow this exact structure:
+
+```go
+func ToolName(
+	obs *observability.Observability,
+	client *rzpsdk.Client,
+) mcpgo.Tool {
+	parameters := []mcpgo.ToolParameter{
+		// Required params first, then optional
+	}
+
+	handler := func(
+		ctx context.Context,
+		r mcpgo.CallToolRequest,
+	) (*mcpgo.ToolResult, error) {
+		client, err := getClientFromContextOrDefault(ctx, client)
+		if err != nil {
+			return mcpgo.NewToolResultError(err.Error()), nil
+		}
+
+		payload := make(map[string]interface{})
+		validator := NewValidator(&r).
+			ValidateAndAddRequiredString(payload, "id")
+			// chain more validators...
+
+		if result, err := validator.HandleErrorsIfAny(); result != nil {
+			return result, err
+		}
+
+		response, err := client.Resource.Method(/* args */)
+		if err != nil {
+			return mcpgo.NewToolResultError(
+				fmt.Sprintf("operation failed: %s", err.Error())), nil
+		}
+
+		return mcpgo.NewToolResultJSON(response)
+	}
+
+	return mcpgo.NewTool("tool_name", "description", parameters, handler)
+}
+```
+
+Required imports:
+
+```go
+import (
+	"context"
+	"fmt"
+
+	rzpsdk "github.com/razorpay/razorpay-go"
+
+	"github.com/razorpay/razorpay-mcp-server/pkg/mcpgo"
+	"github.com/razorpay/razorpay-mcp-server/pkg/observability"
+)
+```
+
+Parameter options: `mcpgo.Required()`, `mcpgo.Description(...)`, `mcpgo.Min(n)`, `mcpgo.Max(n)`, `mcpgo.Pattern(re)`, `mcpgo.Enum(values...)`, `mcpgo.DefaultValue(v)`.
+
+### Step 4: Register Tool
+
+In `pkg/razorpay/tools.go`, add to the appropriate toolset:
+- Read-only tools → `AddReadTools(...)`
+- Mutating tools → `AddWriteTools(...)`
+
+If the resource type is new, create a new toolset:
+
+```go
+newResource := toolsets.NewToolset("resource_name", "Description").
+	AddReadTools(FetchResource(obs, client)).
+	AddWriteTools(CreateResource(obs, client))
+toolsetGroup.AddToolset(newResource)
+```
+
+### Step 5: Write Unit Tests
+
+Create or append to `pkg/razorpay/{resource_type}_test.go`.
+
+Required imports:
+
+```go
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/razorpay/razorpay-go/constants"
+
+	"github.com/razorpay/razorpay-mcp-server/pkg/razorpay/mock"
+)
+```
+
+Mock path construction using SDK constants:
+
+```go
+// Base path (POST/list endpoints)
+basePath := fmt.Sprintf("/%s%s",
+	constants.VERSION_V1, constants.RESOURCE_URL)
+
+// Path with ID (GET/PATCH single resource)
+pathFmt := fmt.Sprintf("/%s%s/%%s",
+	constants.VERSION_V1, constants.RESOURCE_URL)
+```
+
+**CRITICAL**: Never add query parameters to mock paths. The mock server uses Gorilla Mux and does not validate query params.
+
+Required test cases:
+
+| Case | MockHttpClient | ExpectError | Notes |
+|------|---------------|-------------|-------|
+| Success with all params | Returns success response | `false` | Use docs example payload/response |
+| Missing required param (one per required param) | `nil` | `true` | `ExpectedErrMsg: "missing required parameter: X"` |
+| Multiple validation errors | `nil` | `true` | Missing + wrong types |
+| API error | Returns error response | `true` | Test SDK error handling |
+
+Test structure:
+
+```go
+func Test_ToolName(t *testing.T) {
+	apiPath := fmt.Sprintf("/%s%s",
+		constants.VERSION_V1, constants.RESOURCE_URL)
+
+	successResponse := map[string]interface{}{
+		// from docs
+	}
+
+	errorResponse := map[string]interface{}{
+		"error": map[string]interface{}{
+			"code":        "BAD_REQUEST_ERROR",
+			"description": "error message",
+		},
+	}
+
+	tests := []RazorpayToolTestCase{
+		{
+			Name:    "successful operation",
+			Request: map[string]interface{}{/* all params */},
+			MockHttpClient: func() (*http.Client, *httptest.Server) {
+				return mock.NewHTTPClient(mock.Endpoint{
+					Path: apiPath, Method: "POST",
+					Response: successResponse,
+				})
+			},
+			ExpectError:    false,
+			ExpectedResult: successResponse,
+		},
+		// ... negative cases
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			runToolTest(t, tc, ToolName, "Resource")
+		})
+	}
+}
+```
+
+### Step 6: Update README
+
+Add a row to the Available Tools table in the root `README.md`:
+
+```
+| `tool_name` | Brief description | [Resource](docs_url) | ✅ or ❌ |
+```
+
+### Step 7: Run Linter
+
+```bash
+golangci-lint run ./pkg/razorpay/...
+```
+
+Key rules to watch:
+- **lll**: 80 char max line length. Use `// nolint:lll` or string concatenation for long lines.
+- **goimports**: Local prefix `github.com/razorpay/razorpay-mcp-server`. Group: stdlib → external → local.
+- **errcheck**, **bodyclose**, **gosec**: Handle all errors, close response bodies.
+
+Fix all errors. Retry up to 2 times.
+
+### Step 8: Run Tests
+
+```bash
+go test ./pkg/razorpay/... -v -count=1
+```
+
+All tests must pass. Fix failures and retry up to 2 times.
+
+### Step 9: Create Branch, Commit, and Open PR
+
+This step runs **only if `gh` CLI is available**. Check with `gh --version`. If unavailable, skip and inform the user.
+
+**Branch naming** (per CONTRIBUTING.md): `{username}/feat-{tool_name}`
+
+Detect the GitHub username:
+
+```bash
+gh api user --jq '.login'
+```
+
+**Full flow:**
+
+```bash
+# 1. Ensure we're on a clean main
+git checkout main
+git pull origin main
+
+# 2. Create feature branch
+git checkout -b USERNAME/feat-TOOL_NAME
+
+# 3. Stage all changes
+git add pkg/razorpay/{resource}.go \
+       pkg/razorpay/{resource}_test.go \
+       pkg/razorpay/tools.go \
+       README.md
+
+# 4. Commit with conventional format
+git commit -m "feat: add TOOL_NAME tool"
+
+# 5. Push and create PR
+git push -u origin HEAD
+gh pr create \
+  --title "feat: add TOOL_NAME tool" \
+  --body "$(cat <<'EOF'
+## Summary
+- Add `tool_name` tool for [brief description]
+- Implements [HTTP method] [endpoint path]
+- Includes unit tests with full coverage
+
+## Test plan
+- [ ] `go test ./pkg/razorpay/... -v -run Test_ToolName`
+- [ ] `golangci-lint run ./pkg/razorpay/...`
+- [ ] Manual verification with MCP client (optional)
+
+## References
+- API docs: [link]
+EOF
+)"
+```
+
+**Commit message format** (from CONTRIBUTING.md):
+- `feat:` — new tool
+- `fix:` — bug fix
+- `ref:` — refactoring
+- `test:` — test-only changes
+- `chore:` — config, CI, review comments
+
+After creating the PR, **return the PR URL** to the user.
+
+If the repo is a fork, `gh` will automatically offer to create the PR against the upstream `razorpay/razorpay-mcp-server` repository.
+
+## SDK Constants Reference
+
+From `github.com/razorpay/razorpay-go/constants`:
+
+```
+VERSION_V1       = "v1"
+ORDER_URL        = "/orders"
+PAYMENT_URL      = "/payments"
+PaymentLink_URL  = "/payment_links"
+REFUND_URL       = "/refunds"
+CUSTOMER_URL     = "/customers"
+QRCODE_URL       = "/payments/qr_codes"
+SETTLEMENT_URL   = "/settlements"
+PAYOUT_URL       = "/payouts"
+```
+
+If the constant doesn't exist for your resource, check the SDK source or use a string literal.
+
+## Completion Checklist
+
+Include this at the end of every implementation:
+
+- [ ] Tool function implemented in `pkg/razorpay/{resource}.go`
+- [ ] Tool registered in `pkg/razorpay/tools.go`
+- [ ] Unit tests in `pkg/razorpay/{resource}_test.go` (success + all negative cases)
+- [ ] README.md Available Tools table updated
+- [ ] Linter passes (`golangci-lint run`)
+- [ ] Tests pass (`go test ./...`)
+- [ ] Branch created, committed, PR opened (if `gh` available) — link returned to user

--- a/.agents/skills/razorpay-mcp-tool-gen/SKILL.md
+++ b/.agents/skills/razorpay-mcp-tool-gen/SKILL.md
@@ -112,6 +112,67 @@ func ToolName(
 }
 ```
 
+#### Writing LLM-Friendly Tool Descriptions
+
+The description string in `mcpgo.NewTool` is what LLMs read to decide which tool to call. A bad description means the tool gets ignored or misused. Every description **must** answer three questions:
+
+1. **What** does this tool do?
+2. **When** should an LLM pick this tool? (trigger conditions, prerequisites)
+3. **What** constraints or gotchas should the LLM know? (units, required states, return format)
+
+**Structure** (2-4 sentences):
+
+```
+[Action verb] + [what it does] + [key context].
+[When to use / prerequisites]. [Constraints, units, or return format].
+```
+
+**Bad examples** (too vague, no context):
+
+```go
+// Vague — LLM doesn't know when to pick this
+"Fetch an order's details using its ID"
+
+// No constraints — LLM won't know about paise
+"Create a new standard payment link in Razorpay with a specified amount"
+
+// Missing trigger context
+"Fetch all QR codes with optional filtering and pagination"
+```
+
+**Good examples** (actionable, LLM knows when/why):
+
+```go
+// Clear what, when, and constraints
+"Retrieve details of a specific payment by its ID. " +
+	"Use when you need payment status, method, or amount. " +
+	"Amount returned is in paise (100 paise = ₹1)."
+
+// Prerequisites + constraints
+"Capture a previously authorized payment to settle funds. " +
+	"Only works on payments with status 'authorized'. " +
+	"Amount in paise; partial capture supported."
+
+// Trigger context + return format
+"Get all saved payment methods (cards, UPI) " +
+	"for a contact number. " +
+	"Use when the user wants to pay with a saved method. " +
+	"Returns token IDs that can be used with initiate_payment."
+
+// When to use + what makes it different
+"Create a UPI-specific payment link (generates a UPI QR). " +
+	"Use instead of create_payment_link when the customer " +
+	"will pay via UPI. Only supports INR currency."
+```
+
+**Rules:**
+- Start with an action verb (Fetch, Create, Update, Capture, Revoke)
+- Mention units if amounts are involved (`paise`, `smallest currency unit`)
+- Mention prerequisite states (`status must be 'authorized'`)
+- If similar tools exist, explain when to pick THIS one over others
+- If the tool returns data used by other tools, say which ones
+- Keep it under 3-4 sentences; break long lines with `+` concatenation
+
 Required imports:
 
 ```go

--- a/.claude/skills/razorpay-mcp-tool-gen/SKILL.md
+++ b/.claude/skills/razorpay-mcp-tool-gen/SKILL.md
@@ -1,0 +1,350 @@
+---
+name: razorpay-mcp-tool-gen
+description: >-
+  Generate Razorpay MCP server tool implementations from API documentation URLs,
+  curl commands, or request/response examples. Produces Go tool code, unit tests,
+  registration, and README updates. Use when the user provides a Razorpay API doc
+  link, curl example, or request/response payload and wants a new MCP tool created.
+---
+
+# Razorpay MCP Tool Generator
+
+Generate complete MCP tool implementations from Razorpay API docs, curl commands, or request/response examples.
+
+## Input Formats
+
+The user may provide any of:
+
+1. **Razorpay docs URL** — `https://razorpay.com/docs/api/...`
+2. **curl command** — extract method, path, headers, body, and response
+3. **Request/response JSON** — raw payload and expected response
+4. **SDK function signature** — Go SDK function to call
+
+If the **tool name** is not provided or cannot be inferred, **ask the user** before proceeding.
+
+## Workflow
+
+```
+Task Progress:
+- [ ] Step 1: Parse input and extract API contract
+- [ ] Step 2: Determine tool name and resource file
+- [ ] Step 3: Implement tool function
+- [ ] Step 4: Register tool in tools.go
+- [ ] Step 5: Write unit tests
+- [ ] Step 6: Update README.md Available Tools table
+- [ ] Step 7: Run linter — fix errors
+- [ ] Step 8: Run tests — fix errors
+- [ ] Step 9: Create branch, commit, and open PR (if gh available)
+```
+
+### Step 1: Parse Input
+
+**From docs URL**: Fetch the page and extract endpoint path, HTTP method, required/optional params with types and descriptions, and example response.
+
+**From curl**: Parse the method (`-X`), URL path, headers (`-H`), request body (`-d`), and note the response if provided.
+
+**From request/response JSON**: Infer required vs optional fields, types, and construct parameter definitions.
+
+Map each parameter to a validator type:
+
+| JSON type | Parameter helper | Validator method |
+|-----------|-----------------|------------------|
+| string | `mcpgo.WithString` | `ValidateAndAddRequiredString` / `ValidateAndAddOptionalString` |
+| number (int) | `mcpgo.WithNumber` | `ValidateAndAddRequiredInt` / `ValidateAndAddOptionalInt` |
+| number (float) | `mcpgo.WithNumber` | `ValidateAndAddRequiredFloat` / `ValidateAndAddOptionalFloat` |
+| boolean | `mcpgo.WithBoolean` | `ValidateAndAddRequiredBool` / `ValidateAndAddOptionalBool` |
+| object | `mcpgo.WithObject` | `ValidateAndAddRequiredMap` / `ValidateAndAddOptionalMap` |
+| array | `mcpgo.WithArray` | `ValidateAndAddRequiredArray` / `ValidateAndAddOptionalArray` |
+
+For nested objects (e.g., `customer.name` flattened to `customer_name`), use `ValidateAndAddOptionalStringToPath`.
+
+### Step 2: Determine Tool Name and File
+
+Naming conventions:
+- Fetch single: `fetch_{resource}` → `Fetch{Resource}`
+- Fetch list: `fetch_all_{resources}` → `FetchAll{Resources}`
+- Create: `create_{resource}` → `Create{Resource}`
+- Update: `update_{resource}` → `Update{Resource}`
+
+Place the tool in `pkg/razorpay/{resource_type}.go`. Create a new file only if the resource type doesn't already exist.
+
+### Step 3: Implement Tool
+
+Follow this exact structure:
+
+```go
+func ToolName(
+	obs *observability.Observability,
+	client *rzpsdk.Client,
+) mcpgo.Tool {
+	parameters := []mcpgo.ToolParameter{
+		// Required params first, then optional
+	}
+
+	handler := func(
+		ctx context.Context,
+		r mcpgo.CallToolRequest,
+	) (*mcpgo.ToolResult, error) {
+		client, err := getClientFromContextOrDefault(ctx, client)
+		if err != nil {
+			return mcpgo.NewToolResultError(err.Error()), nil
+		}
+
+		payload := make(map[string]interface{})
+		validator := NewValidator(&r).
+			ValidateAndAddRequiredString(payload, "id")
+			// chain more validators...
+
+		if result, err := validator.HandleErrorsIfAny(); result != nil {
+			return result, err
+		}
+
+		response, err := client.Resource.Method(/* args */)
+		if err != nil {
+			return mcpgo.NewToolResultError(
+				fmt.Sprintf("operation failed: %s", err.Error())), nil
+		}
+
+		return mcpgo.NewToolResultJSON(response)
+	}
+
+	return mcpgo.NewTool("tool_name", "description", parameters, handler)
+}
+```
+
+Required imports:
+
+```go
+import (
+	"context"
+	"fmt"
+
+	rzpsdk "github.com/razorpay/razorpay-go"
+
+	"github.com/razorpay/razorpay-mcp-server/pkg/mcpgo"
+	"github.com/razorpay/razorpay-mcp-server/pkg/observability"
+)
+```
+
+Parameter options: `mcpgo.Required()`, `mcpgo.Description(...)`, `mcpgo.Min(n)`, `mcpgo.Max(n)`, `mcpgo.Pattern(re)`, `mcpgo.Enum(values...)`, `mcpgo.DefaultValue(v)`.
+
+### Step 4: Register Tool
+
+In `pkg/razorpay/tools.go`, add to the appropriate toolset:
+- Read-only tools → `AddReadTools(...)`
+- Mutating tools → `AddWriteTools(...)`
+
+If the resource type is new, create a new toolset:
+
+```go
+newResource := toolsets.NewToolset("resource_name", "Description").
+	AddReadTools(FetchResource(obs, client)).
+	AddWriteTools(CreateResource(obs, client))
+toolsetGroup.AddToolset(newResource)
+```
+
+### Step 5: Write Unit Tests
+
+Create or append to `pkg/razorpay/{resource_type}_test.go`.
+
+Required imports:
+
+```go
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/razorpay/razorpay-go/constants"
+
+	"github.com/razorpay/razorpay-mcp-server/pkg/razorpay/mock"
+)
+```
+
+Mock path construction using SDK constants:
+
+```go
+// Base path (POST/list endpoints)
+basePath := fmt.Sprintf("/%s%s",
+	constants.VERSION_V1, constants.RESOURCE_URL)
+
+// Path with ID (GET/PATCH single resource)
+pathFmt := fmt.Sprintf("/%s%s/%%s",
+	constants.VERSION_V1, constants.RESOURCE_URL)
+```
+
+**CRITICAL**: Never add query parameters to mock paths. The mock server uses Gorilla Mux and does not validate query params.
+
+Required test cases:
+
+| Case | MockHttpClient | ExpectError | Notes |
+|------|---------------|-------------|-------|
+| Success with all params | Returns success response | `false` | Use docs example payload/response |
+| Missing required param (one per required param) | `nil` | `true` | `ExpectedErrMsg: "missing required parameter: X"` |
+| Multiple validation errors | `nil` | `true` | Missing + wrong types |
+| API error | Returns error response | `true` | Test SDK error handling |
+
+Test structure:
+
+```go
+func Test_ToolName(t *testing.T) {
+	apiPath := fmt.Sprintf("/%s%s",
+		constants.VERSION_V1, constants.RESOURCE_URL)
+
+	successResponse := map[string]interface{}{
+		// from docs
+	}
+
+	errorResponse := map[string]interface{}{
+		"error": map[string]interface{}{
+			"code":        "BAD_REQUEST_ERROR",
+			"description": "error message",
+		},
+	}
+
+	tests := []RazorpayToolTestCase{
+		{
+			Name:    "successful operation",
+			Request: map[string]interface{}{/* all params */},
+			MockHttpClient: func() (*http.Client, *httptest.Server) {
+				return mock.NewHTTPClient(mock.Endpoint{
+					Path: apiPath, Method: "POST",
+					Response: successResponse,
+				})
+			},
+			ExpectError:    false,
+			ExpectedResult: successResponse,
+		},
+		// ... negative cases
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			runToolTest(t, tc, ToolName, "Resource")
+		})
+	}
+}
+```
+
+### Step 6: Update README
+
+Add a row to the Available Tools table in the root `README.md`:
+
+```
+| `tool_name` | Brief description | [Resource](docs_url) | ✅ or ❌ |
+```
+
+### Step 7: Run Linter
+
+```bash
+golangci-lint run ./pkg/razorpay/...
+```
+
+Key rules to watch:
+- **lll**: 80 char max line length. Use `// nolint:lll` or string concatenation for long lines.
+- **goimports**: Local prefix `github.com/razorpay/razorpay-mcp-server`. Group: stdlib → external → local.
+- **errcheck**, **bodyclose**, **gosec**: Handle all errors, close response bodies.
+
+Fix all errors. Retry up to 2 times.
+
+### Step 8: Run Tests
+
+```bash
+go test ./pkg/razorpay/... -v -count=1
+```
+
+All tests must pass. Fix failures and retry up to 2 times.
+
+### Step 9: Create Branch, Commit, and Open PR
+
+This step runs **only if `gh` CLI is available**. Check with `gh --version`. If unavailable, skip and inform the user.
+
+**Branch naming** (per CONTRIBUTING.md): `{username}/feat-{tool_name}`
+
+Detect the GitHub username:
+
+```bash
+gh api user --jq '.login'
+```
+
+**Full flow:**
+
+```bash
+# 1. Ensure we're on a clean main
+git checkout main
+git pull origin main
+
+# 2. Create feature branch
+git checkout -b USERNAME/feat-TOOL_NAME
+
+# 3. Stage all changes
+git add pkg/razorpay/{resource}.go \
+       pkg/razorpay/{resource}_test.go \
+       pkg/razorpay/tools.go \
+       README.md
+
+# 4. Commit with conventional format
+git commit -m "feat: add TOOL_NAME tool"
+
+# 5. Push and create PR
+git push -u origin HEAD
+gh pr create \
+  --title "feat: add TOOL_NAME tool" \
+  --body "$(cat <<'EOF'
+## Summary
+- Add `tool_name` tool for [brief description]
+- Implements [HTTP method] [endpoint path]
+- Includes unit tests with full coverage
+
+## Test plan
+- [ ] `go test ./pkg/razorpay/... -v -run Test_ToolName`
+- [ ] `golangci-lint run ./pkg/razorpay/...`
+- [ ] Manual verification with MCP client (optional)
+
+## References
+- API docs: [link]
+EOF
+)"
+```
+
+**Commit message format** (from CONTRIBUTING.md):
+- `feat:` — new tool
+- `fix:` — bug fix
+- `ref:` — refactoring
+- `test:` — test-only changes
+- `chore:` — config, CI, review comments
+
+After creating the PR, **return the PR URL** to the user.
+
+If the repo is a fork, `gh` will automatically offer to create the PR against the upstream `razorpay/razorpay-mcp-server` repository.
+
+## SDK Constants Reference
+
+From `github.com/razorpay/razorpay-go/constants`:
+
+```
+VERSION_V1       = "v1"
+ORDER_URL        = "/orders"
+PAYMENT_URL      = "/payments"
+PaymentLink_URL  = "/payment_links"
+REFUND_URL       = "/refunds"
+CUSTOMER_URL     = "/customers"
+QRCODE_URL       = "/payments/qr_codes"
+SETTLEMENT_URL   = "/settlements"
+PAYOUT_URL       = "/payouts"
+```
+
+If the constant doesn't exist for your resource, check the SDK source or use a string literal.
+
+## Completion Checklist
+
+Include this at the end of every implementation:
+
+- [ ] Tool function implemented in `pkg/razorpay/{resource}.go`
+- [ ] Tool registered in `pkg/razorpay/tools.go`
+- [ ] Unit tests in `pkg/razorpay/{resource}_test.go` (success + all negative cases)
+- [ ] README.md Available Tools table updated
+- [ ] Linter passes (`golangci-lint run`)
+- [ ] Tests pass (`go test ./...`)
+- [ ] Branch created, committed, PR opened (if `gh` available) — link returned to user

--- a/.claude/skills/razorpay-mcp-tool-gen/SKILL.md
+++ b/.claude/skills/razorpay-mcp-tool-gen/SKILL.md
@@ -112,6 +112,67 @@ func ToolName(
 }
 ```
 
+#### Writing LLM-Friendly Tool Descriptions
+
+The description string in `mcpgo.NewTool` is what LLMs read to decide which tool to call. A bad description means the tool gets ignored or misused. Every description **must** answer three questions:
+
+1. **What** does this tool do?
+2. **When** should an LLM pick this tool? (trigger conditions, prerequisites)
+3. **What** constraints or gotchas should the LLM know? (units, required states, return format)
+
+**Structure** (2-4 sentences):
+
+```
+[Action verb] + [what it does] + [key context].
+[When to use / prerequisites]. [Constraints, units, or return format].
+```
+
+**Bad examples** (too vague, no context):
+
+```go
+// Vague — LLM doesn't know when to pick this
+"Fetch an order's details using its ID"
+
+// No constraints — LLM won't know about paise
+"Create a new standard payment link in Razorpay with a specified amount"
+
+// Missing trigger context
+"Fetch all QR codes with optional filtering and pagination"
+```
+
+**Good examples** (actionable, LLM knows when/why):
+
+```go
+// Clear what, when, and constraints
+"Retrieve details of a specific payment by its ID. " +
+	"Use when you need payment status, method, or amount. " +
+	"Amount returned is in paise (100 paise = ₹1)."
+
+// Prerequisites + constraints
+"Capture a previously authorized payment to settle funds. " +
+	"Only works on payments with status 'authorized'. " +
+	"Amount in paise; partial capture supported."
+
+// Trigger context + return format
+"Get all saved payment methods (cards, UPI) " +
+	"for a contact number. " +
+	"Use when the user wants to pay with a saved method. " +
+	"Returns token IDs that can be used with initiate_payment."
+
+// When to use + what makes it different
+"Create a UPI-specific payment link (generates a UPI QR). " +
+	"Use instead of create_payment_link when the customer " +
+	"will pay via UPI. Only supports INR currency."
+```
+
+**Rules:**
+- Start with an action verb (Fetch, Create, Update, Capture, Revoke)
+- Mention units if amounts are involved (`paise`, `smallest currency unit`)
+- Mention prerequisite states (`status must be 'authorized'`)
+- If similar tools exist, explain when to pick THIS one over others
+- If the tool returns data used by other tools, say which ones
+- Keep it under 3-4 sentences; break long lines with `+` concatenation
+
 Required imports:
 
 ```go

--- a/.cursor/skills/razorpay-mcp-tool-gen/SKILL.md
+++ b/.cursor/skills/razorpay-mcp-tool-gen/SKILL.md
@@ -1,0 +1,350 @@
+---
+name: razorpay-mcp-tool-gen
+description: >-
+  Generate Razorpay MCP server tool implementations from API documentation URLs,
+  curl commands, or request/response examples. Produces Go tool code, unit tests,
+  registration, and README updates. Use when the user provides a Razorpay API doc
+  link, curl example, or request/response payload and wants a new MCP tool created.
+---
+
+# Razorpay MCP Tool Generator
+
+Generate complete MCP tool implementations from Razorpay API docs, curl commands, or request/response examples.
+
+## Input Formats
+
+The user may provide any of:
+
+1. **Razorpay docs URL** — `https://razorpay.com/docs/api/...`
+2. **curl command** — extract method, path, headers, body, and response
+3. **Request/response JSON** — raw payload and expected response
+4. **SDK function signature** — Go SDK function to call
+
+If the **tool name** is not provided or cannot be inferred, **ask the user** before proceeding.
+
+## Workflow
+
+```
+Task Progress:
+- [ ] Step 1: Parse input and extract API contract
+- [ ] Step 2: Determine tool name and resource file
+- [ ] Step 3: Implement tool function
+- [ ] Step 4: Register tool in tools.go
+- [ ] Step 5: Write unit tests
+- [ ] Step 6: Update README.md Available Tools table
+- [ ] Step 7: Run linter — fix errors
+- [ ] Step 8: Run tests — fix errors
+- [ ] Step 9: Create branch, commit, and open PR (if gh available)
+```
+
+### Step 1: Parse Input
+
+**From docs URL**: Fetch the page and extract endpoint path, HTTP method, required/optional params with types and descriptions, and example response.
+
+**From curl**: Parse the method (`-X`), URL path, headers (`-H`), request body (`-d`), and note the response if provided.
+
+**From request/response JSON**: Infer required vs optional fields, types, and construct parameter definitions.
+
+Map each parameter to a validator type:
+
+| JSON type | Parameter helper | Validator method |
+|-----------|-----------------|------------------|
+| string | `mcpgo.WithString` | `ValidateAndAddRequiredString` / `ValidateAndAddOptionalString` |
+| number (int) | `mcpgo.WithNumber` | `ValidateAndAddRequiredInt` / `ValidateAndAddOptionalInt` |
+| number (float) | `mcpgo.WithNumber` | `ValidateAndAddRequiredFloat` / `ValidateAndAddOptionalFloat` |
+| boolean | `mcpgo.WithBoolean` | `ValidateAndAddRequiredBool` / `ValidateAndAddOptionalBool` |
+| object | `mcpgo.WithObject` | `ValidateAndAddRequiredMap` / `ValidateAndAddOptionalMap` |
+| array | `mcpgo.WithArray` | `ValidateAndAddRequiredArray` / `ValidateAndAddOptionalArray` |
+
+For nested objects (e.g., `customer.name` flattened to `customer_name`), use `ValidateAndAddOptionalStringToPath`.
+
+### Step 2: Determine Tool Name and File
+
+Naming conventions:
+- Fetch single: `fetch_{resource}` → `Fetch{Resource}`
+- Fetch list: `fetch_all_{resources}` → `FetchAll{Resources}`
+- Create: `create_{resource}` → `Create{Resource}`
+- Update: `update_{resource}` → `Update{Resource}`
+
+Place the tool in `pkg/razorpay/{resource_type}.go`. Create a new file only if the resource type doesn't already exist.
+
+### Step 3: Implement Tool
+
+Follow this exact structure:
+
+```go
+func ToolName(
+	obs *observability.Observability,
+	client *rzpsdk.Client,
+) mcpgo.Tool {
+	parameters := []mcpgo.ToolParameter{
+		// Required params first, then optional
+	}
+
+	handler := func(
+		ctx context.Context,
+		r mcpgo.CallToolRequest,
+	) (*mcpgo.ToolResult, error) {
+		client, err := getClientFromContextOrDefault(ctx, client)
+		if err != nil {
+			return mcpgo.NewToolResultError(err.Error()), nil
+		}
+
+		payload := make(map[string]interface{})
+		validator := NewValidator(&r).
+			ValidateAndAddRequiredString(payload, "id")
+			// chain more validators...
+
+		if result, err := validator.HandleErrorsIfAny(); result != nil {
+			return result, err
+		}
+
+		response, err := client.Resource.Method(/* args */)
+		if err != nil {
+			return mcpgo.NewToolResultError(
+				fmt.Sprintf("operation failed: %s", err.Error())), nil
+		}
+
+		return mcpgo.NewToolResultJSON(response)
+	}
+
+	return mcpgo.NewTool("tool_name", "description", parameters, handler)
+}
+```
+
+Required imports:
+
+```go
+import (
+	"context"
+	"fmt"
+
+	rzpsdk "github.com/razorpay/razorpay-go"
+
+	"github.com/razorpay/razorpay-mcp-server/pkg/mcpgo"
+	"github.com/razorpay/razorpay-mcp-server/pkg/observability"
+)
+```
+
+Parameter options: `mcpgo.Required()`, `mcpgo.Description(...)`, `mcpgo.Min(n)`, `mcpgo.Max(n)`, `mcpgo.Pattern(re)`, `mcpgo.Enum(values...)`, `mcpgo.DefaultValue(v)`.
+
+### Step 4: Register Tool
+
+In `pkg/razorpay/tools.go`, add to the appropriate toolset:
+- Read-only tools → `AddReadTools(...)`
+- Mutating tools → `AddWriteTools(...)`
+
+If the resource type is new, create a new toolset:
+
+```go
+newResource := toolsets.NewToolset("resource_name", "Description").
+	AddReadTools(FetchResource(obs, client)).
+	AddWriteTools(CreateResource(obs, client))
+toolsetGroup.AddToolset(newResource)
+```
+
+### Step 5: Write Unit Tests
+
+Create or append to `pkg/razorpay/{resource_type}_test.go`.
+
+Required imports:
+
+```go
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/razorpay/razorpay-go/constants"
+
+	"github.com/razorpay/razorpay-mcp-server/pkg/razorpay/mock"
+)
+```
+
+Mock path construction using SDK constants:
+
+```go
+// Base path (POST/list endpoints)
+basePath := fmt.Sprintf("/%s%s",
+	constants.VERSION_V1, constants.RESOURCE_URL)
+
+// Path with ID (GET/PATCH single resource)
+pathFmt := fmt.Sprintf("/%s%s/%%s",
+	constants.VERSION_V1, constants.RESOURCE_URL)
+```
+
+**CRITICAL**: Never add query parameters to mock paths. The mock server uses Gorilla Mux and does not validate query params.
+
+Required test cases:
+
+| Case | MockHttpClient | ExpectError | Notes |
+|------|---------------|-------------|-------|
+| Success with all params | Returns success response | `false` | Use docs example payload/response |
+| Missing required param (one per required param) | `nil` | `true` | `ExpectedErrMsg: "missing required parameter: X"` |
+| Multiple validation errors | `nil` | `true` | Missing + wrong types |
+| API error | Returns error response | `true` | Test SDK error handling |
+
+Test structure:
+
+```go
+func Test_ToolName(t *testing.T) {
+	apiPath := fmt.Sprintf("/%s%s",
+		constants.VERSION_V1, constants.RESOURCE_URL)
+
+	successResponse := map[string]interface{}{
+		// from docs
+	}
+
+	errorResponse := map[string]interface{}{
+		"error": map[string]interface{}{
+			"code":        "BAD_REQUEST_ERROR",
+			"description": "error message",
+		},
+	}
+
+	tests := []RazorpayToolTestCase{
+		{
+			Name:    "successful operation",
+			Request: map[string]interface{}{/* all params */},
+			MockHttpClient: func() (*http.Client, *httptest.Server) {
+				return mock.NewHTTPClient(mock.Endpoint{
+					Path: apiPath, Method: "POST",
+					Response: successResponse,
+				})
+			},
+			ExpectError:    false,
+			ExpectedResult: successResponse,
+		},
+		// ... negative cases
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			runToolTest(t, tc, ToolName, "Resource")
+		})
+	}
+}
+```
+
+### Step 6: Update README
+
+Add a row to the Available Tools table in the root `README.md`:
+
+```
+| `tool_name` | Brief description | [Resource](docs_url) | ✅ or ❌ |
+```
+
+### Step 7: Run Linter
+
+```bash
+golangci-lint run ./pkg/razorpay/...
+```
+
+Key rules to watch:
+- **lll**: 80 char max line length. Use `// nolint:lll` or string concatenation for long lines.
+- **goimports**: Local prefix `github.com/razorpay/razorpay-mcp-server`. Group: stdlib → external → local.
+- **errcheck**, **bodyclose**, **gosec**: Handle all errors, close response bodies.
+
+Fix all errors. Retry up to 2 times.
+
+### Step 8: Run Tests
+
+```bash
+go test ./pkg/razorpay/... -v -count=1
+```
+
+All tests must pass. Fix failures and retry up to 2 times.
+
+### Step 9: Create Branch, Commit, and Open PR
+
+This step runs **only if `gh` CLI is available**. Check with `gh --version`. If unavailable, skip and inform the user.
+
+**Branch naming** (per CONTRIBUTING.md): `{username}/feat-{tool_name}`
+
+Detect the GitHub username:
+
+```bash
+gh api user --jq '.login'
+```
+
+**Full flow:**
+
+```bash
+# 1. Ensure we're on a clean main
+git checkout main
+git pull origin main
+
+# 2. Create feature branch
+git checkout -b USERNAME/feat-TOOL_NAME
+
+# 3. Stage all changes
+git add pkg/razorpay/{resource}.go \
+       pkg/razorpay/{resource}_test.go \
+       pkg/razorpay/tools.go \
+       README.md
+
+# 4. Commit with conventional format
+git commit -m "feat: add TOOL_NAME tool"
+
+# 5. Push and create PR
+git push -u origin HEAD
+gh pr create \
+  --title "feat: add TOOL_NAME tool" \
+  --body "$(cat <<'EOF'
+## Summary
+- Add `tool_name` tool for [brief description]
+- Implements [HTTP method] [endpoint path]
+- Includes unit tests with full coverage
+
+## Test plan
+- [ ] `go test ./pkg/razorpay/... -v -run Test_ToolName`
+- [ ] `golangci-lint run ./pkg/razorpay/...`
+- [ ] Manual verification with MCP client (optional)
+
+## References
+- API docs: [link]
+EOF
+)"
+```
+
+**Commit message format** (from CONTRIBUTING.md):
+- `feat:` — new tool
+- `fix:` — bug fix
+- `ref:` — refactoring
+- `test:` — test-only changes
+- `chore:` — config, CI, review comments
+
+After creating the PR, **return the PR URL** to the user.
+
+If the repo is a fork, `gh` will automatically offer to create the PR against the upstream `razorpay/razorpay-mcp-server` repository.
+
+## SDK Constants Reference
+
+From `github.com/razorpay/razorpay-go/constants`:
+
+```
+VERSION_V1       = "v1"
+ORDER_URL        = "/orders"
+PAYMENT_URL      = "/payments"
+PaymentLink_URL  = "/payment_links"
+REFUND_URL       = "/refunds"
+CUSTOMER_URL     = "/customers"
+QRCODE_URL       = "/payments/qr_codes"
+SETTLEMENT_URL   = "/settlements"
+PAYOUT_URL       = "/payouts"
+```
+
+If the constant doesn't exist for your resource, check the SDK source or use a string literal.
+
+## Completion Checklist
+
+Include this at the end of every implementation:
+
+- [ ] Tool function implemented in `pkg/razorpay/{resource}.go`
+- [ ] Tool registered in `pkg/razorpay/tools.go`
+- [ ] Unit tests in `pkg/razorpay/{resource}_test.go` (success + all negative cases)
+- [ ] README.md Available Tools table updated
+- [ ] Linter passes (`golangci-lint run`)
+- [ ] Tests pass (`go test ./...`)
+- [ ] Branch created, committed, PR opened (if `gh` available) — link returned to user

--- a/.cursor/skills/razorpay-mcp-tool-gen/SKILL.md
+++ b/.cursor/skills/razorpay-mcp-tool-gen/SKILL.md
@@ -112,6 +112,67 @@ func ToolName(
 }
 ```
 
+#### Writing LLM-Friendly Tool Descriptions
+
+The description string in `mcpgo.NewTool` is what LLMs read to decide which tool to call. A bad description means the tool gets ignored or misused. Every description **must** answer three questions:
+
+1. **What** does this tool do?
+2. **When** should an LLM pick this tool? (trigger conditions, prerequisites)
+3. **What** constraints or gotchas should the LLM know? (units, required states, return format)
+
+**Structure** (2-4 sentences):
+
+```
+[Action verb] + [what it does] + [key context].
+[When to use / prerequisites]. [Constraints, units, or return format].
+```
+
+**Bad examples** (too vague, no context):
+
+```go
+// Vague — LLM doesn't know when to pick this
+"Fetch an order's details using its ID"
+
+// No constraints — LLM won't know about paise
+"Create a new standard payment link in Razorpay with a specified amount"
+
+// Missing trigger context
+"Fetch all QR codes with optional filtering and pagination"
+```
+
+**Good examples** (actionable, LLM knows when/why):
+
+```go
+// Clear what, when, and constraints
+"Retrieve details of a specific payment by its ID. " +
+	"Use when you need payment status, method, or amount. " +
+	"Amount returned is in paise (100 paise = ₹1)."
+
+// Prerequisites + constraints
+"Capture a previously authorized payment to settle funds. " +
+	"Only works on payments with status 'authorized'. " +
+	"Amount in paise; partial capture supported."
+
+// Trigger context + return format
+"Get all saved payment methods (cards, UPI) " +
+	"for a contact number. " +
+	"Use when the user wants to pay with a saved method. " +
+	"Returns token IDs that can be used with initiate_payment."
+
+// When to use + what makes it different
+"Create a UPI-specific payment link (generates a UPI QR). " +
+	"Use instead of create_payment_link when the customer " +
+	"will pay via UPI. Only supports INR currency."
+```
+
+**Rules:**
+- Start with an action verb (Fetch, Create, Update, Capture, Revoke)
+- Mention units if amounts are involved (`paise`, `smallest currency unit`)
+- Mention prerequisite states (`status must be 'authorized'`)
+- If similar tools exist, explain when to pick THIS one over others
+- If the tool returns data used by other tools, say which ones
+- Keep it under 3-4 sentences; break long lines with `+` concatenation
+
 Required imports:
 
 ```go

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,370 @@
+# Agent Instructions
+
+This file provides instructions for AI coding agents working on this repository.
+
+## Project Overview
+
+This is a Go MCP (Model Context Protocol) server that wraps Razorpay APIs. Tools live in `pkg/razorpay/`, are registered in `pkg/razorpay/tools.go`, and tested alongside in `*_test.go` files.
+
+## Key Commands
+
+```bash
+make test    # Run all tests
+make fmt     # Format code
+make lint    # Run golangci-lint
+make build   # Build the binary
+```
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for branch naming (`username/feature`), commit format (`[type]: description`), and PR process.
+
+## Code Style
+
+- 80-char line length max (lll linter)
+- `goimports` with local prefix `github.com/razorpay/razorpay-mcp-server`
+- Full linter config in `.golangci.yaml`
+
+---
+
+# Razorpay MCP Tool Generator
+
+Generate complete MCP tool implementations from Razorpay API docs, curl commands, or request/response examples.
+
+## Input Formats
+
+The user may provide any of:
+
+1. **Razorpay docs URL** — `https://razorpay.com/docs/api/...`
+2. **curl command** — extract method, path, headers, body, and response
+3. **Request/response JSON** — raw payload and expected response
+4. **SDK function signature** — Go SDK function to call
+
+If the **tool name** is not provided or cannot be inferred, **ask the user** before proceeding.
+
+## Workflow
+
+```
+Task Progress:
+- [ ] Step 1: Parse input and extract API contract
+- [ ] Step 2: Determine tool name and resource file
+- [ ] Step 3: Implement tool function
+- [ ] Step 4: Register tool in tools.go
+- [ ] Step 5: Write unit tests
+- [ ] Step 6: Update README.md Available Tools table
+- [ ] Step 7: Run linter — fix errors
+- [ ] Step 8: Run tests — fix errors
+- [ ] Step 9: Create branch, commit, and open PR (if gh available)
+```
+
+### Step 1: Parse Input
+
+**From docs URL**: Fetch the page and extract endpoint path, HTTP method, required/optional params with types and descriptions, and example response.
+
+**From curl**: Parse the method (`-X`), URL path, headers (`-H`), request body (`-d`), and note the response if provided.
+
+**From request/response JSON**: Infer required vs optional fields, types, and construct parameter definitions.
+
+Map each parameter to a validator type:
+
+| JSON type | Parameter helper | Validator method |
+|-----------|-----------------|------------------|
+| string | `mcpgo.WithString` | `ValidateAndAddRequiredString` / `ValidateAndAddOptionalString` |
+| number (int) | `mcpgo.WithNumber` | `ValidateAndAddRequiredInt` / `ValidateAndAddOptionalInt` |
+| number (float) | `mcpgo.WithNumber` | `ValidateAndAddRequiredFloat` / `ValidateAndAddOptionalFloat` |
+| boolean | `mcpgo.WithBoolean` | `ValidateAndAddRequiredBool` / `ValidateAndAddOptionalBool` |
+| object | `mcpgo.WithObject` | `ValidateAndAddRequiredMap` / `ValidateAndAddOptionalMap` |
+| array | `mcpgo.WithArray` | `ValidateAndAddRequiredArray` / `ValidateAndAddOptionalArray` |
+
+For nested objects (e.g., `customer.name` flattened to `customer_name`), use `ValidateAndAddOptionalStringToPath`.
+
+### Step 2: Determine Tool Name and File
+
+Naming conventions:
+- Fetch single: `fetch_{resource}` → `Fetch{Resource}`
+- Fetch list: `fetch_all_{resources}` → `FetchAll{Resources}`
+- Create: `create_{resource}` → `Create{Resource}`
+- Update: `update_{resource}` → `Update{Resource}`
+
+Place the tool in `pkg/razorpay/{resource_type}.go`. Create a new file only if the resource type doesn't already exist.
+
+### Step 3: Implement Tool
+
+Follow this exact structure:
+
+```go
+func ToolName(
+	obs *observability.Observability,
+	client *rzpsdk.Client,
+) mcpgo.Tool {
+	parameters := []mcpgo.ToolParameter{
+		// Required params first, then optional
+	}
+
+	handler := func(
+		ctx context.Context,
+		r mcpgo.CallToolRequest,
+	) (*mcpgo.ToolResult, error) {
+		client, err := getClientFromContextOrDefault(ctx, client)
+		if err != nil {
+			return mcpgo.NewToolResultError(err.Error()), nil
+		}
+
+		payload := make(map[string]interface{})
+		validator := NewValidator(&r).
+			ValidateAndAddRequiredString(payload, "id")
+			// chain more validators...
+
+		if result, err := validator.HandleErrorsIfAny(); result != nil {
+			return result, err
+		}
+
+		response, err := client.Resource.Method(/* args */)
+		if err != nil {
+			return mcpgo.NewToolResultError(
+				fmt.Sprintf("operation failed: %s", err.Error())), nil
+		}
+
+		return mcpgo.NewToolResultJSON(response)
+	}
+
+	return mcpgo.NewTool("tool_name", "description", parameters, handler)
+}
+```
+
+Required imports:
+
+```go
+import (
+	"context"
+	"fmt"
+
+	rzpsdk "github.com/razorpay/razorpay-go"
+
+	"github.com/razorpay/razorpay-mcp-server/pkg/mcpgo"
+	"github.com/razorpay/razorpay-mcp-server/pkg/observability"
+)
+```
+
+Parameter options: `mcpgo.Required()`, `mcpgo.Description(...)`, `mcpgo.Min(n)`, `mcpgo.Max(n)`, `mcpgo.Pattern(re)`, `mcpgo.Enum(values...)`, `mcpgo.DefaultValue(v)`.
+
+### Step 4: Register Tool
+
+In `pkg/razorpay/tools.go`, add to the appropriate toolset:
+- Read-only tools → `AddReadTools(...)`
+- Mutating tools → `AddWriteTools(...)`
+
+If the resource type is new, create a new toolset:
+
+```go
+newResource := toolsets.NewToolset("resource_name", "Description").
+	AddReadTools(FetchResource(obs, client)).
+	AddWriteTools(CreateResource(obs, client))
+toolsetGroup.AddToolset(newResource)
+```
+
+### Step 5: Write Unit Tests
+
+Create or append to `pkg/razorpay/{resource_type}_test.go`.
+
+Required imports:
+
+```go
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/razorpay/razorpay-go/constants"
+
+	"github.com/razorpay/razorpay-mcp-server/pkg/razorpay/mock"
+)
+```
+
+Mock path construction using SDK constants:
+
+```go
+// Base path (POST/list endpoints)
+basePath := fmt.Sprintf("/%s%s",
+	constants.VERSION_V1, constants.RESOURCE_URL)
+
+// Path with ID (GET/PATCH single resource)
+pathFmt := fmt.Sprintf("/%s%s/%%s",
+	constants.VERSION_V1, constants.RESOURCE_URL)
+```
+
+**CRITICAL**: Never add query parameters to mock paths. The mock server uses Gorilla Mux and does not validate query params.
+
+Required test cases:
+
+| Case | MockHttpClient | ExpectError | Notes |
+|------|---------------|-------------|-------|
+| Success with all params | Returns success response | `false` | Use docs example payload/response |
+| Missing required param (one per required param) | `nil` | `true` | `ExpectedErrMsg: "missing required parameter: X"` |
+| Multiple validation errors | `nil` | `true` | Missing + wrong types |
+| API error | Returns error response | `true` | Test SDK error handling |
+
+Test structure:
+
+```go
+func Test_ToolName(t *testing.T) {
+	apiPath := fmt.Sprintf("/%s%s",
+		constants.VERSION_V1, constants.RESOURCE_URL)
+
+	successResponse := map[string]interface{}{
+		// from docs
+	}
+
+	errorResponse := map[string]interface{}{
+		"error": map[string]interface{}{
+			"code":        "BAD_REQUEST_ERROR",
+			"description": "error message",
+		},
+	}
+
+	tests := []RazorpayToolTestCase{
+		{
+			Name:    "successful operation",
+			Request: map[string]interface{}{/* all params */},
+			MockHttpClient: func() (*http.Client, *httptest.Server) {
+				return mock.NewHTTPClient(mock.Endpoint{
+					Path: apiPath, Method: "POST",
+					Response: successResponse,
+				})
+			},
+			ExpectError:    false,
+			ExpectedResult: successResponse,
+		},
+		// ... negative cases
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			runToolTest(t, tc, ToolName, "Resource")
+		})
+	}
+}
+```
+
+### Step 6: Update README
+
+Add a row to the Available Tools table in the root `README.md`:
+
+```
+| `tool_name` | Brief description | [Resource](docs_url) | ✅ or ❌ |
+```
+
+### Step 7: Run Linter
+
+```bash
+golangci-lint run ./pkg/razorpay/...
+```
+
+Key rules to watch:
+- **lll**: 80 char max line length. Use `// nolint:lll` or string concatenation for long lines.
+- **goimports**: Local prefix `github.com/razorpay/razorpay-mcp-server`. Group: stdlib → external → local.
+- **errcheck**, **bodyclose**, **gosec**: Handle all errors, close response bodies.
+
+Fix all errors. Retry up to 2 times.
+
+### Step 8: Run Tests
+
+```bash
+go test ./pkg/razorpay/... -v -count=1
+```
+
+All tests must pass. Fix failures and retry up to 2 times.
+
+### Step 9: Create Branch, Commit, and Open PR
+
+This step runs **only if `gh` CLI is available**. Check with `gh --version`. If unavailable, skip and inform the user.
+
+**Branch naming** (per CONTRIBUTING.md): `{username}/feat-{tool_name}`
+
+Detect the GitHub username:
+
+```bash
+gh api user --jq '.login'
+```
+
+**Full flow:**
+
+```bash
+# 1. Ensure we're on a clean main
+git checkout main
+git pull origin main
+
+# 2. Create feature branch
+git checkout -b USERNAME/feat-TOOL_NAME
+
+# 3. Stage all changes
+git add pkg/razorpay/{resource}.go \
+       pkg/razorpay/{resource}_test.go \
+       pkg/razorpay/tools.go \
+       README.md
+
+# 4. Commit with conventional format
+git commit -m "feat: add TOOL_NAME tool"
+
+# 5. Push and create PR
+git push -u origin HEAD
+gh pr create \
+  --title "feat: add TOOL_NAME tool" \
+  --body "$(cat <<'EOF'
+## Summary
+- Add `tool_name` tool for [brief description]
+- Implements [HTTP method] [endpoint path]
+- Includes unit tests with full coverage
+
+## Test plan
+- [ ] `go test ./pkg/razorpay/... -v -run Test_ToolName`
+- [ ] `golangci-lint run ./pkg/razorpay/...`
+- [ ] Manual verification with MCP client (optional)
+
+## References
+- API docs: [link]
+EOF
+)"
+```
+
+**Commit message format** (from CONTRIBUTING.md):
+- `feat:` — new tool
+- `fix:` — bug fix
+- `ref:` — refactoring
+- `test:` — test-only changes
+- `chore:` — config, CI, review comments
+
+After creating the PR, **return the PR URL** to the user.
+
+If the repo is a fork, `gh` will automatically offer to create the PR against the upstream `razorpay/razorpay-mcp-server` repository.
+
+## SDK Constants Reference
+
+From `github.com/razorpay/razorpay-go/constants`:
+
+```
+VERSION_V1       = "v1"
+ORDER_URL        = "/orders"
+PAYMENT_URL      = "/payments"
+PaymentLink_URL  = "/payment_links"
+REFUND_URL       = "/refunds"
+CUSTOMER_URL     = "/customers"
+QRCODE_URL       = "/payments/qr_codes"
+SETTLEMENT_URL   = "/settlements"
+PAYOUT_URL       = "/payouts"
+```
+
+If the constant doesn't exist for your resource, check the SDK source or use a string literal.
+
+## Completion Checklist
+
+Include this at the end of every implementation:
+
+- [ ] Tool function implemented in `pkg/razorpay/{resource}.go`
+- [ ] Tool registered in `pkg/razorpay/tools.go`
+- [ ] Unit tests in `pkg/razorpay/{resource}_test.go` (success + all negative cases)
+- [ ] README.md Available Tools table updated
+- [ ] Linter passes (`golangci-lint run`)
+- [ ] Tests pass (`go test ./...`)
+- [ ] Branch created, committed, PR opened (if `gh` available) — link returned to user

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,67 @@ func ToolName(
 }
 ```
 
+#### Writing LLM-Friendly Tool Descriptions
+
+The description string in `mcpgo.NewTool` is what LLMs read to decide which tool to call. A bad description means the tool gets ignored or misused. Every description **must** answer three questions:
+
+1. **What** does this tool do?
+2. **When** should an LLM pick this tool? (trigger conditions, prerequisites)
+3. **What** constraints or gotchas should the LLM know? (units, required states, return format)
+
+**Structure** (2-4 sentences):
+
+```
+[Action verb] + [what it does] + [key context].
+[When to use / prerequisites]. [Constraints, units, or return format].
+```
+
+**Bad examples** (too vague, no context):
+
+```go
+// Vague — LLM doesn't know when to pick this
+"Fetch an order's details using its ID"
+
+// No constraints — LLM won't know about paise
+"Create a new standard payment link in Razorpay with a specified amount"
+
+// Missing trigger context
+"Fetch all QR codes with optional filtering and pagination"
+```
+
+**Good examples** (actionable, LLM knows when/why):
+
+```go
+// Clear what, when, and constraints
+"Retrieve details of a specific payment by its ID. " +
+	"Use when you need payment status, method, or amount. " +
+	"Amount returned is in paise (100 paise = ₹1)."
+
+// Prerequisites + constraints
+"Capture a previously authorized payment to settle funds. " +
+	"Only works on payments with status 'authorized'. " +
+	"Amount in paise; partial capture supported."
+
+// Trigger context + return format
+"Get all saved payment methods (cards, UPI) " +
+	"for a contact number. " +
+	"Use when the user wants to pay with a saved method. " +
+	"Returns token IDs that can be used with initiate_payment."
+
+// When to use + what makes it different
+"Create a UPI-specific payment link (generates a UPI QR). " +
+	"Use instead of create_payment_link when the customer " +
+	"will pay via UPI. Only supports INR currency."
+```
+
+**Rules:**
+- Start with an action verb (Fetch, Create, Update, Capture, Revoke)
+- Mention units if amounts are involved (`paise`, `smallest currency unit`)
+- Mention prerequisite states (`status must be 'authorized'`)
+- If similar tools exist, explain when to pick THIS one over others
+- If the tool returns data used by other tools, say which ones
+- Keep it under 3-4 sentences; break long lines with `+` concatenation
+
 Required imports:
 
 ```go

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Currently, the Razorpay MCP Server provides the following tools:
 | `fetch_payout_by_id`                 | Fetch the payout details with payout ID                | [Payout](https://razorpay.com/docs/api/x/payouts/fetch-with-id) | ✅ |
 | `fetch_tokens`     | Get all saved payment methods for a contact number     | [Token](https://razorpay.com/docs/payments/payment-gateway/s2s-integration/recurring-payments/cards/tokens/) | ✅ |
 | `revoke_token`     | Revoke a saved payment method (token) for a customer   | [Token](https://razorpay.com/docs/payments/payment-gateway/s2s-integration/recurring-payments/upi-otm/collect/tokens/#24-cancel-token) | ✅ |
+| `create_subscription_registration_auth_link` | Create subscription registration authorization link for recurring payments | [Subscription Registration](https://razorpay.com/docs/api/payments/recurring-payments/) | ✅ |
 | `detect_stack` | Detect project language/framework for checkout integration | N/A (MCP Integration Helper) | ✅ |
 | `integrate_razorpay_checkout` | Generate end-to-end Razorpay Standard Checkout integration code for supported frameworks | N/A (MCP Integration Helper) | ✅ |
 

--- a/pkg/razorpay/subscription_registration.go
+++ b/pkg/razorpay/subscription_registration.go
@@ -1,0 +1,218 @@
+package razorpay
+
+import (
+	"context"
+	"fmt"
+
+	rzpsdk "github.com/razorpay/razorpay-go"
+	"github.com/razorpay/razorpay-go/constants"
+
+	"github.com/razorpay/razorpay-mcp-server/pkg/mcpgo"
+	"github.com/razorpay/razorpay-mcp-server/pkg/observability"
+)
+
+// CreateSubscriptionRegistrationAuthLink returns a tool that creates
+// subscription registration authorization links
+func CreateSubscriptionRegistrationAuthLink(
+	obs *observability.Observability,
+	client *rzpsdk.Client,
+) mcpgo.Tool {
+	parameters := []mcpgo.ToolParameter{
+		mcpgo.WithString(
+			"customer_name",
+			mcpgo.Description("Name of the customer"),
+			mcpgo.Required(),
+		),
+		mcpgo.WithString(
+			"customer_email",
+			mcpgo.Description("Email address of the customer"),
+			mcpgo.Required(),
+		),
+		mcpgo.WithString(
+			"customer_contact",
+			mcpgo.Description("Contact number of the customer "+
+				"(e.g., +60102102460)"),
+			mcpgo.Required(),
+		),
+		mcpgo.WithString(
+			"type",
+			mcpgo.Description("Type of the authorization link. Must be 'link'"),
+			mcpgo.Required(),
+			mcpgo.Enum("link"),
+		),
+		mcpgo.WithString(
+			"amount",
+			mcpgo.Description("Amount for the authorization transaction "+
+				"in the smallest currency unit (e.g., paise for INR, "+
+				"sen for MYR). Example: '100' for 1.00 MYR"),
+			mcpgo.Required(),
+		),
+		mcpgo.WithString(
+			"currency",
+			mcpgo.Description("Three-letter ISO currency code "+
+				"(e.g., INR, MYR, USD)"),
+			mcpgo.Required(),
+		),
+		mcpgo.WithString(
+			"description",
+			mcpgo.Description("Description of the registration link purpose"),
+			mcpgo.Required(),
+		),
+		mcpgo.WithString(
+			"subscription_registration_method",
+			mcpgo.Description("Payment method for subscription registration. "+
+				"Supported values: 'card', 'emandate', 'nach'"),
+			mcpgo.Required(),
+		),
+		mcpgo.WithString(
+			"subscription_registration_max_amount",
+			mcpgo.Description("Maximum amount that can be charged in a single "+
+				"transaction in smallest currency unit"),
+			mcpgo.Required(),
+		),
+		mcpgo.WithString(
+			"subscription_registration_expire_at",
+			mcpgo.Description("Unix timestamp when the subscription "+
+				"registration expires"),
+			mcpgo.Required(),
+		),
+		mcpgo.WithString(
+			"subscription_registration_frequency",
+			mcpgo.Description("Frequency of the subscription charges. "+
+				"Supported values: 'as_presented', 'daily', 'weekly', "+
+				"'monthly', 'yearly'"),
+			mcpgo.Required(),
+		),
+		mcpgo.WithString(
+			"receipt",
+			mcpgo.Description("Receipt number for the transaction. "+
+				"Must be unique"),
+		),
+		mcpgo.WithBoolean(
+			"email_notify",
+			mcpgo.Description("Whether to send email notification "+
+				"to the customer. Default: true"),
+		),
+		mcpgo.WithBoolean(
+			"sms_notify",
+			mcpgo.Description("Whether to send SMS notification "+
+				"to the customer. Default: true"),
+		),
+		mcpgo.WithNumber(
+			"expire_by",
+			mcpgo.Description("Unix timestamp when the auth link expires"),
+		),
+		mcpgo.WithObject(
+			"notes",
+			mcpgo.Description("Key-value pairs for additional information. "+
+				"Maximum 15 pairs, each value limited to 256 characters"),
+		),
+	}
+
+	handler := func(
+		ctx context.Context,
+		r mcpgo.CallToolRequest,
+	) (*mcpgo.ToolResult, error) {
+		client, err := getClientFromContextOrDefault(ctx, client)
+		if err != nil {
+			return mcpgo.NewToolResultError(err.Error()), nil
+		}
+
+		payload := make(map[string]interface{})
+		customer := make(map[string]interface{})
+		subscriptionReg := make(map[string]interface{})
+
+		validator := NewValidator(&r).
+			ValidateAndAddOptionalStringToPath(
+				customer, "customer_name", "name").
+			ValidateAndAddOptionalStringToPath(
+				customer, "customer_email", "email").
+			ValidateAndAddOptionalStringToPath(
+				customer, "customer_contact", "contact").
+			ValidateAndAddRequiredString(payload, "type").
+			ValidateAndAddRequiredString(payload, "amount").
+			ValidateAndAddRequiredString(payload, "currency").
+			ValidateAndAddRequiredString(payload, "description").
+			ValidateAndAddOptionalStringToPath(
+				subscriptionReg, "subscription_registration_method", "method").
+			ValidateAndAddOptionalStringToPath(
+				subscriptionReg, "subscription_registration_max_amount",
+				"max_amount").
+			ValidateAndAddOptionalStringToPath(
+				subscriptionReg, "subscription_registration_expire_at",
+				"expire_at").
+			ValidateAndAddOptionalStringToPath(
+				subscriptionReg, "subscription_registration_frequency",
+				"frequency").
+			ValidateAndAddOptionalString(payload, "receipt").
+			ValidateAndAddOptionalBool(payload, "email_notify").
+			ValidateAndAddOptionalBool(payload, "sms_notify").
+			ValidateAndAddOptionalInt(payload, "expire_by").
+			ValidateAndAddOptionalMap(payload, "notes")
+
+		// Validate required nested fields manually
+		if _, exists := customer["name"]; !exists {
+			validator = validator.addError(
+				fmt.Errorf("missing required parameter: customer_name"))
+		}
+		if _, exists := customer["email"]; !exists {
+			validator = validator.addError(
+				fmt.Errorf("missing required parameter: customer_email"))
+		}
+		if _, exists := customer["contact"]; !exists {
+			validator = validator.addError(
+				fmt.Errorf("missing required parameter: customer_contact"))
+		}
+		if _, exists := subscriptionReg["method"]; !exists {
+			validator = validator.addError(fmt.Errorf(
+				"missing required parameter: subscription_registration_method"))
+		}
+		if _, exists := subscriptionReg["max_amount"]; !exists {
+			validator = validator.addError(fmt.Errorf(
+				"missing required parameter: " +
+					"subscription_registration_max_amount"))
+		}
+		if _, exists := subscriptionReg["expire_at"]; !exists {
+			validator = validator.addError(fmt.Errorf(
+				"missing required parameter: " +
+					"subscription_registration_expire_at"))
+		}
+		if _, exists := subscriptionReg["frequency"]; !exists {
+			validator = validator.addError(fmt.Errorf(
+				"missing required parameter: " +
+					"subscription_registration_frequency"))
+		}
+
+		if result, err := validator.HandleErrorsIfAny(); result != nil {
+			return result, err
+		}
+
+		// Add customer and subscription_registration objects to payload
+		payload["customer"] = customer
+		payload["subscription_registration"] = subscriptionReg
+
+		// Make API call
+		url := fmt.Sprintf("/%s/subscription_registration/auth_links",
+			constants.VERSION_V1)
+		response, err := client.Request.Post(url, payload, nil)
+		if err != nil {
+			return mcpgo.NewToolResultError(
+				fmt.Sprintf(
+					"creating subscription registration auth link failed: %s",
+					err.Error())), nil
+		}
+
+		return mcpgo.NewToolResultJSON(response)
+	}
+
+	return mcpgo.NewTool(
+		"create_subscription_registration_auth_link",
+		"Create a subscription registration authorization link for recurring "+
+			"payments. Use when setting up recurring payment mandates via "+
+			"card, emandate, or NACH. The link allows customers to authorize "+
+			"future charges up to a specified maximum amount. "+
+			"Amount is in smallest currency unit (paise for INR, sen for MYR).",
+		parameters,
+		handler,
+	)
+}

--- a/pkg/razorpay/subscription_registration_test.go
+++ b/pkg/razorpay/subscription_registration_test.go
@@ -1,0 +1,365 @@
+package razorpay
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/razorpay/razorpay-go/constants"
+
+	"github.com/razorpay/razorpay-mcp-server/pkg/razorpay/mock"
+)
+
+func Test_CreateSubscriptionRegistrationAuthLink(t *testing.T) {
+	apiPath := fmt.Sprintf("/%s/subscription_registration/auth_links",
+		constants.VERSION_V1)
+
+	successResponse := map[string]interface{}{
+		"id":          "inv_xxxxxxxxxxxxx",
+		"entity":      "invoice",
+		"type":        "link",
+		"amount":      float64(100),
+		"currency":    "MYR",
+		"description": "Registration Link for Nur Aisyah",
+		"customer": map[string]interface{}{
+			"name":    "Dhruv Mittal",
+			"email":   "dhruv.mittal@razorpay.com",
+			"contact": "+60102102460",
+		},
+		"subscription_registration": map[string]interface{}{
+			"method":       "card",
+			"max_amount":   "500",
+			"expire_at":    "1798703336",
+			"frequency":    "as_presented",
+			"auth_type":    "netbanking",
+			"bank_account": map[string]interface{}{},
+		},
+		"receipt":      "Receipt No. 1323",
+		"email_notify": true,
+		"sms_notify":   true,
+		"expire_by":    float64(1798703336),
+		"notes": map[string]interface{}{
+			"note_key 1": "Beam me up Scotty",
+			"note_key 2": "Tea. Earl Gray. Hot.",
+		},
+		"short_url": "https://rzp.io/i/xxxxx",
+		"status":    "issued",
+	}
+
+	errorResponse := map[string]interface{}{
+		"error": map[string]interface{}{
+			"code":        "BAD_REQUEST_ERROR",
+			"description": "Invalid request parameters",
+		},
+	}
+
+	tests := []RazorpayToolTestCase{
+		{
+			Name: "successful creation with all parameters",
+			Request: map[string]interface{}{
+				"customer_name":                        "Dhruv Mittal",
+				"customer_email":                       "dhruv.mittal@razorpay.com",
+				"customer_contact":                     "+60102102460",
+				"type":                                 "link",
+				"amount":                               "100",
+				"currency":                             "MYR",
+				"description":                          "Registration Link for Nur Aisyah",
+				"subscription_registration_method":     "card",
+				"subscription_registration_max_amount": "500",
+				"subscription_registration_expire_at":  "1798703336",
+				"subscription_registration_frequency":  "as_presented",
+				"receipt":                              "Receipt No. 1323",
+				"email_notify":                         true,
+				"sms_notify":                           true,
+				"expire_by":                            float64(1798703336),
+				"notes": map[string]interface{}{
+					"note_key 1": "Beam me up Scotty",
+					"note_key 2": "Tea. Earl Gray. Hot.",
+				},
+			},
+			MockHttpClient: func() (*http.Client, *httptest.Server) {
+				return mock.NewHTTPClient(mock.Endpoint{
+					Path:     apiPath,
+					Method:   "POST",
+					Response: successResponse,
+				})
+			},
+			ExpectError:    false,
+			ExpectedResult: successResponse,
+		},
+		{
+			Name: "successful creation with only required parameters",
+			Request: map[string]interface{}{
+				"customer_name":                        "John Doe",
+				"customer_email":                       "john@example.com",
+				"customer_contact":                     "+919876543210",
+				"type":                                 "link",
+				"amount":                               "100",
+				"currency":                             "INR",
+				"description":                          "Test registration",
+				"subscription_registration_method":     "emandate",
+				"subscription_registration_max_amount": "1000",
+				"subscription_registration_expire_at":  "1798703336",
+				"subscription_registration_frequency":  "monthly",
+			},
+			MockHttpClient: func() (*http.Client, *httptest.Server) {
+				return mock.NewHTTPClient(mock.Endpoint{
+					Path:     apiPath,
+					Method:   "POST",
+					Response: successResponse,
+				})
+			},
+			ExpectError:    false,
+			ExpectedResult: successResponse,
+		},
+		{
+			Name: "missing required parameter: customer_name",
+			Request: map[string]interface{}{
+				"customer_email":                       "dhruv.mittal@razorpay.com",
+				"customer_contact":                     "+60102102460",
+				"type":                                 "link",
+				"amount":                               "100",
+				"currency":                             "MYR",
+				"description":                          "Registration Link",
+				"subscription_registration_method":     "card",
+				"subscription_registration_max_amount": "500",
+				"subscription_registration_expire_at":  "1798703336",
+				"subscription_registration_frequency":  "as_presented",
+			},
+			MockHttpClient: nil,
+			ExpectError:    true,
+			ExpectedErrMsg: "missing required parameter: customer_name",
+		},
+		{
+			Name: "missing required parameter: customer_email",
+			Request: map[string]interface{}{
+				"customer_name":                        "Dhruv Mittal",
+				"customer_contact":                     "+60102102460",
+				"type":                                 "link",
+				"amount":                               "100",
+				"currency":                             "MYR",
+				"description":                          "Registration Link",
+				"subscription_registration_method":     "card",
+				"subscription_registration_max_amount": "500",
+				"subscription_registration_expire_at":  "1798703336",
+				"subscription_registration_frequency":  "as_presented",
+			},
+			MockHttpClient: nil,
+			ExpectError:    true,
+			ExpectedErrMsg: "missing required parameter: customer_email",
+		},
+		{
+			Name: "missing required parameter: customer_contact",
+			Request: map[string]interface{}{
+				"customer_name":                        "Dhruv Mittal",
+				"customer_email":                       "dhruv.mittal@razorpay.com",
+				"type":                                 "link",
+				"amount":                               "100",
+				"currency":                             "MYR",
+				"description":                          "Registration Link",
+				"subscription_registration_method":     "card",
+				"subscription_registration_max_amount": "500",
+				"subscription_registration_expire_at":  "1798703336",
+				"subscription_registration_frequency":  "as_presented",
+			},
+			MockHttpClient: nil,
+			ExpectError:    true,
+			ExpectedErrMsg: "missing required parameter: customer_contact",
+		},
+		{
+			Name: "missing required parameter: type",
+			Request: map[string]interface{}{
+				"customer_name":                        "Dhruv Mittal",
+				"customer_email":                       "dhruv.mittal@razorpay.com",
+				"customer_contact":                     "+60102102460",
+				"amount":                               "100",
+				"currency":                             "MYR",
+				"description":                          "Registration Link",
+				"subscription_registration_method":     "card",
+				"subscription_registration_max_amount": "500",
+				"subscription_registration_expire_at":  "1798703336",
+				"subscription_registration_frequency":  "as_presented",
+			},
+			MockHttpClient: nil,
+			ExpectError:    true,
+			ExpectedErrMsg: "missing required parameter: type",
+		},
+		{
+			Name: "missing required parameter: amount",
+			Request: map[string]interface{}{
+				"customer_name":                        "Dhruv Mittal",
+				"customer_email":                       "dhruv.mittal@razorpay.com",
+				"customer_contact":                     "+60102102460",
+				"type":                                 "link",
+				"currency":                             "MYR",
+				"description":                          "Registration Link",
+				"subscription_registration_method":     "card",
+				"subscription_registration_max_amount": "500",
+				"subscription_registration_expire_at":  "1798703336",
+				"subscription_registration_frequency":  "as_presented",
+			},
+			MockHttpClient: nil,
+			ExpectError:    true,
+			ExpectedErrMsg: "missing required parameter: amount",
+		},
+		{
+			Name: "missing required parameter: currency",
+			Request: map[string]interface{}{
+				"customer_name":                        "Dhruv Mittal",
+				"customer_email":                       "dhruv.mittal@razorpay.com",
+				"customer_contact":                     "+60102102460",
+				"type":                                 "link",
+				"amount":                               "100",
+				"description":                          "Registration Link",
+				"subscription_registration_method":     "card",
+				"subscription_registration_max_amount": "500",
+				"subscription_registration_expire_at":  "1798703336",
+				"subscription_registration_frequency":  "as_presented",
+			},
+			MockHttpClient: nil,
+			ExpectError:    true,
+			ExpectedErrMsg: "missing required parameter: currency",
+		},
+		{
+			Name: "missing required parameter: description",
+			Request: map[string]interface{}{
+				"customer_name":                        "Dhruv Mittal",
+				"customer_email":                       "dhruv.mittal@razorpay.com",
+				"customer_contact":                     "+60102102460",
+				"type":                                 "link",
+				"amount":                               "100",
+				"currency":                             "MYR",
+				"subscription_registration_method":     "card",
+				"subscription_registration_max_amount": "500",
+				"subscription_registration_expire_at":  "1798703336",
+				"subscription_registration_frequency":  "as_presented",
+			},
+			MockHttpClient: nil,
+			ExpectError:    true,
+			ExpectedErrMsg: "missing required parameter: description",
+		},
+		{
+			Name: "missing subscription_registration_method",
+			Request: map[string]interface{}{
+				"customer_name":                        "Dhruv Mittal",
+				"customer_email":                       "dhruv.mittal@razorpay.com",
+				"customer_contact":                     "+60102102460",
+				"type":                                 "link",
+				"amount":                               "100",
+				"currency":                             "MYR",
+				"description":                          "Registration Link",
+				"subscription_registration_max_amount": "500",
+				"subscription_registration_expire_at":  "1798703336",
+				"subscription_registration_frequency":  "as_presented",
+			},
+			MockHttpClient: nil,
+			ExpectError:    true,
+			ExpectedErrMsg: "missing required parameter: " +
+				"subscription_registration_method",
+		},
+		{
+			Name: "missing subscription_registration_max_amount",
+			Request: map[string]interface{}{
+				"customer_name":                       "Dhruv Mittal",
+				"customer_email":                      "dhruv.mittal@razorpay.com",
+				"customer_contact":                    "+60102102460",
+				"type":                                "link",
+				"amount":                              "100",
+				"currency":                            "MYR",
+				"description":                         "Registration Link",
+				"subscription_registration_method":    "card",
+				"subscription_registration_expire_at": "1798703336",
+				"subscription_registration_frequency": "as_presented",
+			},
+			MockHttpClient: nil,
+			ExpectError:    true,
+			ExpectedErrMsg: "missing required parameter: " +
+				"subscription_registration_max_amount",
+		},
+		{
+			Name: "missing subscription_registration_expire_at",
+			Request: map[string]interface{}{
+				"customer_name":                        "Dhruv Mittal",
+				"customer_email":                       "dhruv.mittal@razorpay.com",
+				"customer_contact":                     "+60102102460",
+				"type":                                 "link",
+				"amount":                               "100",
+				"currency":                             "MYR",
+				"description":                          "Registration Link",
+				"subscription_registration_method":     "card",
+				"subscription_registration_max_amount": "500",
+				"subscription_registration_frequency":  "as_presented",
+			},
+			MockHttpClient: nil,
+			ExpectError:    true,
+			ExpectedErrMsg: "missing required parameter: " +
+				"subscription_registration_expire_at",
+		},
+		{
+			Name: "missing subscription_registration_frequency",
+			Request: map[string]interface{}{
+				"customer_name":                        "Dhruv Mittal",
+				"customer_email":                       "dhruv.mittal@razorpay.com",
+				"customer_contact":                     "+60102102460",
+				"type":                                 "link",
+				"amount":                               "100",
+				"currency":                             "MYR",
+				"description":                          "Registration Link",
+				"subscription_registration_method":     "card",
+				"subscription_registration_max_amount": "500",
+				"subscription_registration_expire_at":  "1798703336",
+			},
+			MockHttpClient: nil,
+			ExpectError:    true,
+			ExpectedErrMsg: "missing required parameter: " +
+				"subscription_registration_frequency",
+		},
+		{
+			Name: "multiple validation errors",
+			Request: map[string]interface{}{
+				"customer_name": "Dhruv Mittal",
+				"type":          123,
+				"amount":        true,
+				"currency":      456,
+			},
+			MockHttpClient: nil,
+			ExpectError:    true,
+		},
+		{
+			Name: "API error response",
+			Request: map[string]interface{}{
+				"customer_name":                        "Dhruv Mittal",
+				"customer_email":                       "dhruv.mittal@razorpay.com",
+				"customer_contact":                     "+60102102460",
+				"type":                                 "link",
+				"amount":                               "100",
+				"currency":                             "MYR",
+				"description":                          "Registration Link",
+				"subscription_registration_method":     "card",
+				"subscription_registration_max_amount": "500",
+				"subscription_registration_expire_at":  "1798703336",
+				"subscription_registration_frequency":  "as_presented",
+			},
+			MockHttpClient: func() (*http.Client, *httptest.Server) {
+				return mock.NewHTTPClient(mock.Endpoint{
+					Path:     apiPath,
+					Method:   "POST",
+					Response: errorResponse,
+				})
+			},
+			ExpectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			runToolTest(
+				t,
+				tc,
+				CreateSubscriptionRegistrationAuthLink,
+				"SubscriptionRegistration",
+			)
+		})
+	}
+}

--- a/pkg/razorpay/tools.go
+++ b/pkg/razorpay/tools.go
@@ -101,6 +101,13 @@ func NewToolSets(
 			CreateInstantSettlement(obs, client),
 		)
 
+	subscriptionRegistration := toolsets.NewToolset(
+		"subscription_registration",
+		"Razorpay Subscription Registration related tools").
+		AddWriteTools(
+			CreateSubscriptionRegistrationAuthLink(obs, client),
+		)
+
 	// Add the single custom tool to an existing toolset
 	payments.AddWriteTools(FetchSavedPaymentMethods(obs, client)).
 		AddWriteTools(RevokeToken(obs, client))
@@ -123,6 +130,7 @@ func NewToolSets(
 	toolsetGroup.AddToolset(payouts)
 	toolsetGroup.AddToolset(qrCodes)
 	toolsetGroup.AddToolset(settlements)
+	toolsetGroup.AddToolset(subscriptionRegistration)
 
 	// Enable the requested features
 	if err := toolsetGroup.EnableToolsets(enabledToolsets); err != nil {


### PR DESCRIPTION
## Summary
- Add `create_subscription_registration_auth_link` tool for creating subscription registration authorization links
- Implements POST `/v1/subscription_registration/auth_links` endpoint
- Includes unit tests with full coverage (positive cases, all negative cases for required parameters, edge cases)

## Implementation Details
- Created new file `pkg/razorpay/subscription_registration.go` with the tool implementation
- Registered tool in `pkg/razorpay/tools.go` under new `subscription_registration` toolset
- Added comprehensive unit tests in `pkg/razorpay/subscription_registration_test.go`
- Updated README.md Available Tools table

## Test Coverage
- ✅ Successful creation with all parameters
- ✅ Successful creation with only required parameters
- ✅ Missing required parameter tests for each required field (customer_name, customer_email, customer_contact, type, amount, currency, description, subscription_registration_method, subscription_registration_max_amount, subscription_registration_expire_at, subscription_registration_frequency)
- ✅ Multiple validation errors test
- ✅ API error response test

## Test Plan
- [x] `go test ./pkg/razorpay/... -v -run Test_CreateSubscriptionRegistrationAuthLink`
- [x] `golangci-lint run ./pkg/razorpay/`
- [x] All existing tests pass: `go test ./pkg/razorpay/... -count=1`
- [ ] Manual verification with MCP client (optional)

## References
- API endpoint: POST `/v1/subscription_registration/auth_links`
- Curl command provided by user for subscription registration auth links

Made with [Cursor](https://cursor.com)