### PR TITLE
fix: enforce missing tool parameter schema constraints

### DIFF
--- a/pkg/mcpgo/tool.go
+++ b/pkg/mcpgo/tool.go
@@ -233,6 +233,8 @@ type mark3labsToolImpl struct {
 }
 
 // ParameterSchema returns the JSON schema for a named tool parameter.
+// It is intended for tests that verify parameter constraints (enum, max,
+// pattern) are declared in the tool schema, not only in descriptions.
 func ParameterSchema(tool Tool, name string) (map[string]interface{}, bool) {
 	t, ok := tool.(*mark3labsToolImpl)
 	if !ok {

--- a/pkg/mcpgo/tool.go
+++ b/pkg/mcpgo/tool.go
@@ -232,6 +232,22 @@ type mark3labsToolImpl struct {
 	isReadOnly  bool
 }
 
+// ParameterSchema returns the JSON schema for a named tool parameter.
+func ParameterSchema(tool Tool, name string) (map[string]interface{}, bool) {
+	t, ok := tool.(*mark3labsToolImpl)
+	if !ok {
+		return nil, false
+	}
+
+	for _, param := range t.parameters {
+		if param.Name == name {
+			return param.Schema, true
+		}
+	}
+
+	return nil, false
+}
+
 // NewTool creates a new tool with the given
 // Name, description, parameters and handler
 func NewTool(

--- a/pkg/mcpgo/tool_test.go
+++ b/pkg/mcpgo/tool_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewTool(t *testing.T) {
@@ -502,6 +503,72 @@ func TestPropertyOption_Items(t *testing.T) {
 		itemSchema := map[string]interface{}{"type": "string"}
 		Items(itemSchema)(schema)
 		assert.NotContains(t, schema, "items")
+	})
+}
+
+func TestParameterSchema(t *testing.T) {
+	t.Run("returns schema for existing parameter", func(t *testing.T) {
+		tool := NewTool(
+			"test-tool",
+			"Test",
+			[]ToolParameter{
+				WithString(
+					"speed",
+					Enum("normal", "optimum"),
+				),
+			},
+			func(ctx context.Context, req CallToolRequest) (*ToolResult, error) {
+				return NewToolResultText("success"), nil
+			},
+		)
+
+		schema, ok := ParameterSchema(tool, "speed")
+		require.True(t, ok)
+		assert.Equal(t, []interface{}{"normal", "optimum"}, schema["enum"])
+	})
+
+	t.Run("returns false for missing parameter", func(t *testing.T) {
+		tool := NewTool(
+			"test-tool",
+			"Test",
+			[]ToolParameter{WithString("speed")},
+			func(ctx context.Context, req CallToolRequest) (*ToolResult, error) {
+				return NewToolResultText("success"), nil
+			},
+		)
+
+		_, ok := ParameterSchema(tool, "missing")
+		assert.False(t, ok)
+	})
+
+	t.Run("constraints appear in MCP tool input schema", func(t *testing.T) {
+		tool := NewTool(
+			"test-tool",
+			"Test",
+			[]ToolParameter{
+				WithString("speed", Enum("normal", "optimum")),
+				WithNumber("count", Min(1), Max(100)),
+			},
+			func(ctx context.Context, req CallToolRequest) (*ToolResult, error) {
+				return NewToolResultText("success"), nil
+			},
+		)
+
+		mcpTool := tool.toMCPServerTool()
+		raw, err := json.Marshal(mcpTool.Tool)
+		require.NoError(t, err)
+
+		var decoded map[string]interface{}
+		require.NoError(t, json.Unmarshal(raw, &decoded))
+
+		inputSchema := decoded["inputSchema"].(map[string]interface{})
+		props := inputSchema["properties"].(map[string]interface{})
+		speed := props["speed"].(map[string]interface{})
+		count := props["count"].(map[string]interface{})
+
+		assert.Equal(t, []interface{}{"normal", "optimum"}, speed["enum"])
+		assert.Equal(t, float64(1), count["minimum"])
+		assert.Equal(t, float64(100), count["maximum"])
 	})
 }
 

--- a/pkg/razorpay/payment_links.go
+++ b/pkg/razorpay/payment_links.go
@@ -27,6 +27,7 @@ func CreatePaymentLink(
 			"currency",
 			mcpgo.Description("Three-letter ISO code for the currency (e.g., INR)"),
 			mcpgo.Required(),
+			mcpgo.Pattern("^[A-Z]{3}$"),
 		),
 		mcpgo.WithString(
 			"description",
@@ -47,6 +48,7 @@ func CreatePaymentLink(
 		mcpgo.WithString(
 			"reference_id",
 			mcpgo.Description("Reference number tagged to a Payment Link. Must be unique for each Payment Link. Max 40 characters."), // nolint:lll
+			mcpgo.Max(40),
 		),
 		mcpgo.WithString(
 			"customer_name",
@@ -168,6 +170,7 @@ func CreateUpiPaymentLink(
 			"currency",
 			mcpgo.Description("Three-letter ISO code for the currency (e.g., INR). UPI links are only supported in INR"), // nolint:lll
 			mcpgo.Required(),
+			mcpgo.Enum("INR"),
 		),
 		mcpgo.WithString(
 			"description",
@@ -188,6 +191,7 @@ func CreateUpiPaymentLink(
 		mcpgo.WithString(
 			"reference_id",
 			mcpgo.Description("Reference number tagged to a Payment Link. Must be unique for each Payment Link. Max 40 characters."), // nolint:lll
+			mcpgo.Max(40),
 		),
 		mcpgo.WithString(
 			"customer_name",

--- a/pkg/razorpay/payouts.go
+++ b/pkg/razorpay/payouts.go
@@ -81,6 +81,7 @@ func FetchAllPayouts(
 				"Maximum value is 100. This can be used for pagination,"+
 				"in combination with the skip parameter"),
 			mcpgo.Min(1),
+			mcpgo.Max(100),
 		),
 		mcpgo.WithNumber(
 			"skip",

--- a/pkg/razorpay/refunds.go
+++ b/pkg/razorpay/refunds.go
@@ -33,6 +33,7 @@ func CreateRefund(
 			mcpgo.Description("The speed at which the refund is to be "+
 				"processed. Default is 'normal'. For instant refunds, speed "+
 				"is set as 'optimum'."),
+			mcpgo.Enum("normal", "optimum"),
 		),
 		mcpgo.WithObject(
 			"notes",

--- a/pkg/razorpay/schema_constraints_test.go
+++ b/pkg/razorpay/schema_constraints_test.go
@@ -1,0 +1,58 @@
+package razorpay
+
+import (
+	"testing"
+
+	rzpsdk "github.com/razorpay/razorpay-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/razorpay/razorpay-mcp-server/pkg/mcpgo"
+)
+
+func TestSchemaConstraints(t *testing.T) {
+	obs := CreateTestObservability()
+	client := &rzpsdk.Client{}
+
+	t.Run("create_refund speed enum", func(t *testing.T) {
+		schema, ok := mcpgo.ParameterSchema(CreateRefund(obs, client), "speed")
+		require.True(t, ok)
+		assert.Equal(t, []interface{}{"normal", "optimum"}, schema["enum"])
+	})
+
+	t.Run("create_payment_link currency pattern", func(t *testing.T) {
+		schema, ok := mcpgo.ParameterSchema(
+			CreatePaymentLink(obs, client), "currency")
+		require.True(t, ok)
+		assert.Equal(t, "^[A-Z]{3}$", schema["pattern"])
+	})
+
+	t.Run("create_payment_link reference_id max length", func(t *testing.T) {
+		schema, ok := mcpgo.ParameterSchema(
+			CreatePaymentLink(obs, client), "reference_id")
+		require.True(t, ok)
+		assert.Equal(t, 40, schema["maxLength"])
+	})
+
+	t.Run("create_upi_payment_link currency INR only", func(t *testing.T) {
+		schema, ok := mcpgo.ParameterSchema(
+			CreateUpiPaymentLink(obs, client), "currency")
+		require.True(t, ok)
+		assert.Equal(t, []interface{}{"INR"}, schema["enum"])
+	})
+
+	t.Run("create_upi_payment_link reference_id max length", func(t *testing.T) {
+		schema, ok := mcpgo.ParameterSchema(
+			CreateUpiPaymentLink(obs, client), "reference_id")
+		require.True(t, ok)
+		assert.Equal(t, 40, schema["maxLength"])
+	})
+
+	t.Run("fetch_all_payouts count bounds", func(t *testing.T) {
+		schema, ok := mcpgo.ParameterSchema(
+			FetchAllPayouts(obs, client), "count")
+		require.True(t, ok)
+		assert.Equal(t, float64(1), schema["minimum"])
+		assert.Equal(t, float64(100), schema["maximum"])
+	})
+}


### PR DESCRIPTION
## Description

This PR closes the gap between tool parameter descriptions and their JSON schemas. Several tools documented constraints (allowed enum values, max length, max count, currency format) but did not enforce them via `mcpgo` schema options, so MCP clients could pass invalid values without schema-level rejection.

Changes:
- **`create_refund.speed`** — `Enum("normal", "optimum")`
- **`create_payment_link.reference_id`** / **`create_upi_payment_link.reference_id`** — `Max(40)`
- **`create_payment_link.currency`** — `Pattern("^[A-Z]{3}$")` (matches `create_order.currency`)
- **`create_upi_payment_link.currency`** — `Enum("INR")` (UPI links are INR-only)
- **`fetch_all_payouts.count`** — `Max(100)` (matches sibling list tools)
- Added **`mcpgo.ParameterSchema()`** helper and **`schema_constraints_test.go`** to verify constraints on affected tools
- Documented schema constraint patterns in **`pkg/razorpay/README.md`**
- Added MCP **`inputSchema`** verification test in **`pkg/mcpgo/tool_test.go`**

## Related Issues

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, code improvements only)
- [ ] Documentation update
- [ ] Performance improvement

## Testing

- [x] Manual testing — MCP `inputSchema` verified via integration-style test
- [x] Added unit tests
- [ ] Added integration tests (if applicable)
- [x] All tests pass locally

```bash
go test ./pkg/razorpay/... -run TestSchemaConstraints -v -count=1
go test ./pkg/mcpgo/... -run TestParameterSchema -v -count=1
go test ./... -count=1
```

## Checklist

- [x] I have followed the code style of this project
- [x] I have added comments to code where necessary, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary
- [x] I have verified that my changes do not introduce new warnings or errors
- [x] I have checked for and resolved any merge conflicts
- [x] I have considered the performance implications of my changes

## Additional Information

Schema-only changes — no runtime handler logic was modified. Existing valid API calls are unaffected; invalid values that previously slipped through at the schema layer will now be rejected earlier by MCP clients that respect JSON Schema constraints.

**Files changed:**

| File | Change |
|------|--------|
| `pkg/razorpay/refunds.go` | `speed` enum |
| `pkg/razorpay/payment_links.go` | `reference_id` max length, currency pattern/enum |
| `pkg/razorpay/payouts.go` | `count` max |
| `pkg/razorpay/schema_constraints_test.go` | Schema assertion tests |
| `pkg/razorpay/README.md` | Schema constraint documentation |
| `pkg/mcpgo/tool.go` | `ParameterSchema()` helper |
| `pkg/mcpgo/tool_test.go` | ParameterSchema + MCP inputSchema tests |