### PR TITLE
fix: preserve all expand query values

### DIFF
--- a/pkg/razorpay/orders_test.go
+++ b/pkg/razorpay/orders_test.go
@@ -673,6 +673,23 @@ func Test_FetchAllOrders(t *testing.T) {
 			ExpectedResult: ordersResp,
 		},
 		{
+			Name: "successful fetch all orders with multiple expand values",
+			Request: map[string]interface{}{
+				"expand": []interface{}{"payments", "transfers"},
+			},
+			MockHttpClient: func() (*http.Client, *httptest.Server) {
+				return mock.NewHTTPClient(
+					mock.Endpoint{
+						Path:     fetchAllOrdersPath,
+						Method:   "GET",
+						Response: ordersResp,
+					},
+				)
+			},
+			ExpectError:    false,
+			ExpectedResult: ordersResp,
+		},
+		{
 			Name: "multiple validation errors",
 			Request: map[string]interface{}{
 				"count":  "not-a-number",

--- a/pkg/razorpay/tools_params.go
+++ b/pkg/razorpay/tools_params.go
@@ -261,9 +261,8 @@ func (v *Validator) ValidateAndAddExpand(
 	}
 
 	if len(*expand) > 0 {
-		for _, val := range *expand {
-			params["expand[]"] = val
-		}
+		// razorpay-go serializes []string into repeated expand[]= query params.
+		params["expand[]"] = *expand
 	}
 	return v
 }

--- a/pkg/razorpay/tools_params_test.go
+++ b/pkg/razorpay/tools_params_test.go
@@ -339,25 +339,25 @@ func TestValidatorExpand(t *testing.T) {
 	tests := []struct {
 		name         string
 		args         map[string]interface{}
-		expectExpand string
+		expectExpand []string
 		expectError  bool
 	}{
 		{
 			name:         "valid expand param",
 			args:         map[string]interface{}{"expand": []interface{}{"payments"}},
-			expectExpand: "payments",
+			expectExpand: []string{"payments"},
 			expectError:  false,
 		},
 		{
 			name:         "empty expand array",
 			args:         map[string]interface{}{"expand": []interface{}{}},
-			expectExpand: "",
+			expectExpand: nil,
 			expectError:  false,
 		},
 		{
 			name:         "invalid expand type",
 			args:         map[string]interface{}{"expand": "not an array"},
-			expectExpand: "",
+			expectExpand: nil,
 			expectError:  true,
 		},
 	}
@@ -376,7 +376,7 @@ func TestValidatorExpand(t *testing.T) {
 				assert.True(t, validator.HasErrors(), "Expected validation error")
 			} else {
 				assert.False(t, validator.HasErrors(), "Did not expect validation error")
-				if tt.expectExpand != "" {
+				if tt.expectExpand != nil {
 					assert.Equal(t,
 						tt.expectExpand,
 						result["expand[]"],
@@ -999,8 +999,7 @@ func TestValidateAndAddExpand(t *testing.T) {
 		validator := NewValidator(request).ValidateAndAddExpand(params)
 
 		assert.False(t, validator.HasErrors())
-		// The function sets expand[] for each value, so check the last one
-		assert.Equal(t, "customer", params["expand[]"])
+		assert.Equal(t, []string{"payments", "customer"}, params["expand[]"])
 	})
 
 	t.Run("missing expand parameter", func(t *testing.T) {

--- a/pkg/razorpay/tools_params_test.go
+++ b/pkg/razorpay/tools_params_test.go
@@ -1,8 +1,12 @@
 package razorpay
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	rzpsdk "github.com/razorpay/razorpay-go"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/razorpay/razorpay-mcp-server/pkg/mcpgo"
@@ -1028,6 +1032,39 @@ func TestValidateAndAddExpand(t *testing.T) {
 
 		assert.True(t, validator.HasErrors())
 	})
+}
+
+func TestValidateAndAddExpandSDKSerialization(t *testing.T) {
+	var capturedQuery string
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			capturedQuery = r.URL.RawQuery
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"entity": "collection",
+				"count":  0,
+				"items":  []interface{}{},
+			})
+		},
+	))
+	defer server.Close()
+
+	client := rzpsdk.NewClient("sample_key", "sample_secret")
+	client.Order.Request.BaseURL = server.URL
+
+	params := make(map[string]interface{})
+	args := map[string]interface{}{
+		"expand": []string{"payments", "transfers"},
+	}
+	request := &mcpgo.CallToolRequest{Arguments: args}
+	validator := NewValidator(request).ValidateAndAddExpand(params)
+
+	assert.False(t, validator.HasErrors())
+
+	_, err := client.Order.All(params, nil)
+	assert.NoError(t, err)
+	assert.Contains(t, capturedQuery, "expand%5B%5D=payments")
+	assert.Contains(t, capturedQuery, "expand%5B%5D=transfers")
 }
 
 // Test for token validation functions edge cases


### PR DESCRIPTION
## Description
Fixes a bug in `ValidateAndAddExpand` where only the last expand value was sent to the Razorpay API. The loop overwrote the same `params["expand[]"]` map key on each iteration, so multi-value expands (e.g. `["payments", "transfers"]`) silently dropped all but the last entry.

The fix assigns the full `[]string` slice in one step. razorpay-go already serializes `[]string` into repeated `expand[]=` query params. This affects `fetch_all_orders` and `fetch_all_instant_settlements`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, code improvements only)
- [ ] Documentation update
- [ ] Performance improvement

## Testing
- [x] Manual testing
- [x] Added unit tests
- [x] Added integration tests (if applicable)
- [x] All tests pass locally

- Updated `TestValidatorExpand` and `TestValidateAndAddExpand` to assert the full expand slice is preserved
- Added `TestValidateAndAddExpandSDKSerialization` to verify repeated `expand[]=` query params via razorpay-go
- Added multi-expand tool test in `Test_FetchAllOrders`
- Ran `go test ./pkg/razorpay/... -count=1` — all pass

## Checklist
- [x] I have followed the code style of this project
- [x] I have added comments to code where necessary, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary
- [x] I have verified that my changes do not introduce new warnings or errors
- [x] I have checked for and resolved any merge conflicts
- [x] I have considered the performance implications of my changes

## Additional Information
**Before:** `expand: ["payments", "transfers"]` → only `transfers` sent to API  
**After:** `expand: ["payments", "transfers"]` → both values sent as `expand[]=payments&expand[]=transfers`