### PR TITLE
fix: make refund amount optional for full refunds

### DIFF
--- a/pkg/razorpay/refunds.go
+++ b/pkg/razorpay/refunds.go
@@ -78,6 +78,10 @@ func CreateRefund(
 		var refund map[string]interface{}
 
 		if amountVal, hasAmount := data["amount"]; hasAmount {
+			if amountVal.(float64) < 100 {
+				return mcpgo.NewToolResultError(
+					"amount must be at least 100 paise"), nil
+			}
 			// Partial refund: SDK Refund always sets amount on the request body.
 			delete(data, "amount")
 			refund, err = client.Payment.Refund(

--- a/pkg/razorpay/refunds.go
+++ b/pkg/razorpay/refunds.go
@@ -78,7 +78,7 @@ func CreateRefund(
 		var refund map[string]interface{}
 
 		if amountVal, hasAmount := data["amount"]; hasAmount {
-			// Partial refund: SDK always sets amount on the request body.
+			// Partial refund: SDK Refund always sets amount on the request body.
 			delete(data, "amount")
 			refund, err = client.Payment.Refund(
 				paymentID,
@@ -87,7 +87,8 @@ func CreateRefund(
 				nil,
 			)
 		} else {
-			// Full refund: omit amount from the body per Razorpay API contract.
+			// Full refund: SDK Refund has no amount-less path, so post
+			// directly and omit amount from the body per Razorpay API contract.
 			refundURL := fmt.Sprintf(
 				"/%s%s/%s/refund",
 				constants.VERSION_V1,

--- a/pkg/razorpay/refunds.go
+++ b/pkg/razorpay/refunds.go
@@ -2,8 +2,11 @@ package razorpay
 
 import (
 	"context"
+	"fmt"
+	"net/url"
 
 	rzpsdk "github.com/razorpay/razorpay-go"
+	"github.com/razorpay/razorpay-go/constants"
 
 	"github.com/razorpay/razorpay-mcp-server/pkg/mcpgo"
 	"github.com/razorpay/razorpay-mcp-server/pkg/observability"
@@ -23,9 +26,10 @@ func CreateRefund(
 		),
 		mcpgo.WithNumber(
 			"amount",
-			mcpgo.Description("Payment amount in paise (smallest currency unit). "+
-				"For INR: 100 paise = ₹1. Example: for ₹295, use 29500"),
-			mcpgo.Required(),
+			mcpgo.Description("Optional refund amount in paise (smallest "+
+				"currency unit). Omit to refund the full captured amount. "+
+				"When provided, minimum is 100 paise (₹1). "+
+				"Example: for ₹295, use 29500"),
 			mcpgo.Min(100), // Minimum amount is 100 (1.00 in currency)
 		),
 		mcpgo.WithString(
@@ -61,7 +65,7 @@ func CreateRefund(
 
 		validator := NewValidator(&r).
 			ValidateAndAddRequiredString(payload, "payment_id").
-			ValidateAndAddRequiredFloat(payload, "amount").
+			ValidateAndAddOptionalFloat(data, "amount").
 			ValidateAndAddOptionalString(data, "speed").
 			ValidateAndAddOptionalString(data, "receipt").
 			ValidateAndAddOptionalMap(data, "notes")
@@ -70,9 +74,28 @@ func CreateRefund(
 			return result, err
 		}
 
-		refund, err := client.Payment.Refund(
-			payload["payment_id"].(string),
-			int(payload["amount"].(float64)), data, nil)
+		paymentID := payload["payment_id"].(string)
+		var refund map[string]interface{}
+
+		if amountVal, hasAmount := data["amount"]; hasAmount {
+			// Partial refund: SDK always sets amount on the request body.
+			delete(data, "amount")
+			refund, err = client.Payment.Refund(
+				paymentID,
+				int(amountVal.(float64)),
+				data,
+				nil,
+			)
+		} else {
+			// Full refund: omit amount from the body per Razorpay API contract.
+			refundURL := fmt.Sprintf(
+				"/%s%s/%s/refund",
+				constants.VERSION_V1,
+				constants.PAYMENT_URL,
+				url.PathEscape(paymentID),
+			)
+			refund, err = client.Payment.Request.Post(refundURL, data, nil)
+		}
 		if err != nil {
 			return mcpgo.NewToolResultError(
 				formatErrorMessage("creating refund failed", err)), nil
@@ -83,9 +106,10 @@ func CreateRefund(
 
 	return mcpgo.NewTool(
 		"create_refund",
-		"Use this tool to create a normal refund for a payment. "+
-			"Amount should be in paise (smallest currency unit). "+
-			"For INR: 100 paise = ₹1. Example: for ₹295, use 29500",
+		"Create a normal refund for a captured payment. "+
+			"Omit amount to refund the full captured amount; provide amount "+
+			"in paise for a partial refund (minimum 100 paise when provided). "+
+			"Payment must have status 'captured'.",
 		parameters,
 		handler,
 	)

--- a/pkg/razorpay/refunds_test.go
+++ b/pkg/razorpay/refunds_test.go
@@ -138,6 +138,16 @@ func Test_CreateRefund(t *testing.T) {
 			ExpectedErrMsg: "creating refund failed: Razorpay API error: Bad request",
 		},
 		{
+			Name: "amount below minimum",
+			Request: map[string]interface{}{
+				"payment_id": "pay_29QQoUBi66xm2f",
+				"amount":     float64(50),
+			},
+			MockHttpClient: nil,
+			ExpectError:    true,
+			ExpectedErrMsg: "amount must be at least 100 paise",
+		},
+		{
 			Name: "missing payment_id",
 			Request: map[string]interface{}{
 				"amount": float64(500100),

--- a/pkg/razorpay/refunds_test.go
+++ b/pkg/razorpay/refunds_test.go
@@ -44,11 +44,28 @@ func Test_CreateRefund(t *testing.T) {
 
 	tests := []RazorpayToolTestCase{
 		{
-			Name: "successful full refund",
+			Name: "successful partial refund with amount",
 			Request: map[string]interface{}{
 				"payment_id": "pay_29QQoUBi66xm2f",
 				"amount":     float64(500100),
 				"receipt":    "Receipt No. 31",
+			},
+			MockHttpClient: func() (*http.Client, *httptest.Server) {
+				return mock.NewHTTPClient(
+					mock.Endpoint{
+						Path:     fmt.Sprintf(createRefundPathFmt, "pay_29QQoUBi66xm2f"),
+						Method:   "POST",
+						Response: successfulRefundResp,
+					},
+				)
+			},
+			ExpectError:    false,
+			ExpectedResult: successfulRefundResp,
+		},
+		{
+			Name: "successful full refund without amount",
+			Request: map[string]interface{}{
+				"payment_id": "pay_29QQoUBi66xm2f",
 			},
 			MockHttpClient: func() (*http.Client, *httptest.Server) {
 				return mock.NewHTTPClient(
@@ -115,6 +132,15 @@ func Test_CreateRefund(t *testing.T) {
 			},
 			ExpectError:    true,
 			ExpectedErrMsg: "creating refund failed: Razorpay API error: Bad request",
+		},
+		{
+			Name: "missing payment_id",
+			Request: map[string]interface{}{
+				"amount": float64(500100),
+			},
+			MockHttpClient: nil,
+			ExpectError:    true,
+			ExpectedErrMsg: "missing required parameter: payment_id",
 		},
 		{
 			Name: "multiple validation errors",

--- a/pkg/razorpay/refunds_test.go
+++ b/pkg/razorpay/refunds_test.go
@@ -1,12 +1,16 @@
 package razorpay
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	rzpsdk "github.com/razorpay/razorpay-go"
 	"github.com/razorpay/razorpay-go/constants"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/razorpay/razorpay-mcp-server/pkg/razorpay/mock"
 )
@@ -165,6 +169,82 @@ func Test_CreateRefund(t *testing.T) {
 			runToolTest(t, tc, CreateRefund, "Refund")
 		})
 	}
+}
+
+func Test_CreateRefundRequestBody(t *testing.T) {
+	createRefundPathFmt := fmt.Sprintf(
+		"/%s%s/%%s/refund",
+		constants.VERSION_V1,
+		constants.PAYMENT_URL,
+	)
+	paymentID := "pay_29QQoUBi66xm2f"
+	refundPath := fmt.Sprintf(createRefundPathFmt, paymentID)
+
+	successResp := map[string]interface{}{
+		"id":         "rfnd_FP8QHiV938haTz",
+		"entity":     "refund",
+		"amount":     float64(500100),
+		"payment_id": paymentID,
+		"status":     "processed",
+	}
+
+	t.Run("full refund omits amount from request body", func(t *testing.T) {
+		var requestBody map[string]interface{}
+		server := httptest.NewServer(http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Equal(t, refundPath, r.URL.Path)
+				err := json.NewDecoder(r.Body).Decode(&requestBody)
+				assert.NoError(t, err)
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(successResp)
+			},
+		))
+		defer server.Close()
+
+		obs := CreateTestObservability()
+		rzpClient := rzpsdk.NewClient("sample_key", "sample_secret")
+		rzpClient.Payment.Request.BaseURL = server.URL
+
+		tool := CreateRefund(obs, rzpClient)
+		request := createMCPRequest(map[string]interface{}{
+			"payment_id": paymentID,
+		})
+		result, err := tool.GetHandler()(context.Background(), request)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		_, hasAmount := requestBody["amount"]
+		assert.False(t, hasAmount, "full refund must omit amount from body")
+	})
+
+	t.Run("partial refund includes amount in request body", func(t *testing.T) {
+		var requestBody map[string]interface{}
+		server := httptest.NewServer(http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				err := json.NewDecoder(r.Body).Decode(&requestBody)
+				assert.NoError(t, err)
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(successResp)
+			},
+		))
+		defer server.Close()
+
+		obs := CreateTestObservability()
+		rzpClient := rzpsdk.NewClient("sample_key", "sample_secret")
+		rzpClient.Payment.Request.BaseURL = server.URL
+
+		tool := CreateRefund(obs, rzpClient)
+		request := createMCPRequest(map[string]interface{}{
+			"payment_id": paymentID,
+			"amount":     float64(500100),
+		})
+		result, err := tool.GetHandler()(context.Background(), request)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, float64(500100), requestBody["amount"])
+	})
 }
 
 func Test_FetchRefund(t *testing.T) {

--- a/pkg/razorpay/refunds_test.go
+++ b/pkg/razorpay/refunds_test.go
@@ -218,6 +218,36 @@ func Test_CreateRefundRequestBody(t *testing.T) {
 		assert.False(t, hasAmount, "full refund must omit amount from body")
 	})
 
+	t.Run("full refund with optional params omits amount", func(t *testing.T) {
+		var requestBody map[string]interface{}
+		server := httptest.NewServer(http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				err := json.NewDecoder(r.Body).Decode(&requestBody)
+				assert.NoError(t, err)
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(successResp)
+			},
+		))
+		defer server.Close()
+
+		obs := CreateTestObservability()
+		rzpClient := rzpsdk.NewClient("sample_key", "sample_secret")
+		rzpClient.Payment.Request.BaseURL = server.URL
+
+		tool := CreateRefund(obs, rzpClient)
+		request := createMCPRequest(map[string]interface{}{
+			"payment_id": paymentID,
+			"speed":      "optimum",
+		})
+		result, err := tool.GetHandler()(context.Background(), request)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		_, hasAmount := requestBody["amount"]
+		assert.False(t, hasAmount, "full refund must omit amount from body")
+		assert.Equal(t, "optimum", requestBody["speed"])
+	})
+
 	t.Run("partial refund includes amount in request body", func(t *testing.T) {
 		var requestBody map[string]interface{}
 		server := httptest.NewServer(http.HandlerFunc(


### PR DESCRIPTION
Fixes an API-fidelity issue in `create_refund` where `amount` was incorrectly required. In Razorpay's normal refund API, omitting `amount` refunds the full captured amount. The tool previously forced agents to always supply an exact amount, requiring an extra `fetch_payment` call and increasing the risk of partial-refund mistakes.

### What changed

**`pkg/razorpay/refunds.go`**
- Removed `Required()` from `amount`; kept `mcpgo.Min(100)` on the parameter schema
- Switched validation from `ValidateAndAddRequiredFloat` to `ValidateAndAddOptionalFloat`
- Added runtime validation: when `amount` is provided and `< 100`, returns `amount must be at least 100 paise`
- Updated parameter and tool descriptions to explain full vs partial refund modes

**Refund behavior**
- **Full refund** (`amount` omitted): calls `client.Payment.Request.Post` directly so `amount` is omitted from the request body. The SDK's `Payment.Refund` always injects `amount`, so it cannot be used for full refunds.
- **Partial refund** (`amount` provided): validates `amount >= 100`, then calls `client.Payment.Refund` with the amount in paise plus optional fields (`speed`, `notes`, `receipt`)

**Minimum amount when provided**
- Enforced in two places: `mcpgo.Min(100)` on the MCP schema and runtime handler check before calling the API

**`pkg/razorpay/refunds_test.go`**
- `successful partial refund with amount`
- `successful full refund without amount`
- `amount below minimum` — `amount: 50` expects validation error
- `missing payment_id`
- `Test_CreateRefundRequestBody`:
  - `full refund omits amount from request body`
  - `full refund with optional params omits amount`
  - `partial refund includes amount in request body`

Existing cases retained: refund with `speed`, API server error, and multiple validation errors.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, code improvements only)
- [ ] Documentation update
- [ ] Performance improvement

## Testing

- [x] Manual testing — built binary; verified full/partial refund paths and request-body behavior via unit tests
- [x] Added unit tests
- [ ] Added integration tests (if applicable) — N/A; `Test_CreateRefundRequestBody` uses the real razorpay-go client against a mock HTTP server
- [x] All tests pass locally — `go test ./... -count=1`

**Commands run:**
- `gofmt -w pkg/razorpay/refunds.go pkg/razorpay/refunds_test.go`
- `go test ./pkg/razorpay/... -count=1 -run Test_CreateRefund -v`
- `go test ./... -count=1`
- `golangci-lint run ./pkg/razorpay/...`

## Checklist

- [x] I have followed the code style of this project
- [x] I have added comments to code where necessary, particularly in hard-to-understand areas
- [ ] I have updated the documentation where necessary — N/A; tool/parameter descriptions updated in code; `README.md` intentionally not included in this PR
- [x] I have verified that my changes do not introduce new warnings or errors
- [x] I have checked for and resolved any merge conflicts — up to date with `upstream/main`
- [x] I have considered the performance implications of my changes

## Additional Information

**Behavior change:** Agents can now call `create_refund` with only `payment_id` to refund the full captured amount. Partial refunds require `amount >= 100` paise.