### PR TITLE
fix: prevent fabricated email in initiate_payment

### DIFF
--- a/pkg/razorpay/payments.go
+++ b/pkg/razorpay/payments.go
@@ -511,7 +511,8 @@ func addFallbackNextStepInstructions(
 	}
 }
 
-// addContactAndEmailToPaymentData adds contact and email to payment data
+// addContactAndEmailToPaymentData adds contact and email to payment data.
+// Email is only included when explicitly provided — never fabricated from contact.
 func addContactAndEmailToPaymentData(
 	paymentData map[string]interface{},
 	params map[string]interface{},
@@ -521,11 +522,9 @@ func addContactAndEmailToPaymentData(
 		paymentData["contact"] = contact
 	}
 
-	// Add email if provided, otherwise generate from contact
+	// Add email only when explicitly provided
 	if email, exists := params["email"]; exists && email != "" {
 		paymentData["email"] = email
-	} else if contact, exists := paymentData["contact"]; exists && contact != "" {
-		paymentData["email"] = contact.(string) + "@mcp.razorpay.com"
 	}
 }
 
@@ -738,7 +737,9 @@ func InitiatePayment(
 		),
 		mcpgo.WithString(
 			"email",
-			mcpgo.Description("Customer's email address (optional)"),
+			mcpgo.Description("Customer's email address (optional). Omit when "+
+				"unknown — never use placeholder addresses. Provide for email "+
+				"receipts and notifications."),
 		),
 		mcpgo.WithString(
 			"contact",
@@ -846,6 +847,21 @@ func InitiatePayment(
 			return mcpgo.NewToolResultError(err.Error()), nil
 		}
 
+		// Warn when contact is provided without email (email omitted from API)
+		hasContact := false
+		if contact, ok := params["contact"]; ok && contact != "" {
+			hasContact = true
+		}
+		hasEmail := false
+		if email, ok := params["email"]; ok && email != "" {
+			hasEmail = true
+		}
+		if hasContact && !hasEmail {
+			response["warning"] = "No email was provided; email was omitted " +
+				"from the payment request. Provide email for receipts and " +
+				"notifications."
+		}
+
 		return mcpgo.NewToolResultJSON(response)
 	}
 
@@ -860,6 +876,8 @@ func InitiatePayment(
 			"which automatically sets UPI with flow='intent' and API returns UPI URL. "+
 			"Supports additional parameters like customer_id, email, "+
 			"contact, save, and recurring. "+
+			"Email is optional — when omitted, no email is sent to the API; "+
+			"provide a real email for receipts and notifications. "+
 			"Returns payment details including next action steps if required.",
 		parameters,
 		handler,

--- a/pkg/razorpay/payments_test.go
+++ b/pkg/razorpay/payments_test.go
@@ -773,6 +773,9 @@ func Test_InitiatePayment(t *testing.T) {
 				"next_tool_params": map[string]interface{}{
 					"payment_id": "pay_MT48CvBhIC98MQ",
 				},
+				"warning": "No email was provided; email was omitted " +
+					"from the payment request. Provide email for receipts and " +
+					"notifications.",
 			},
 		},
 		{
@@ -960,6 +963,9 @@ func Test_InitiatePayment(t *testing.T) {
 				"next_tool_params": map[string]interface{}{
 					"payment_id": "pay_MT48CvBhIC98MQ",
 				},
+				"warning": "No email was provided; email was omitted " +
+					"from the payment request. Provide email for receipts and " +
+					"notifications.",
 			},
 		},
 		{
@@ -3009,7 +3015,7 @@ func Test_addContactAndEmailToPaymentData_scenarios(t *testing.T) {
 			},
 		},
 		{
-			name: "only contact provided - email generated",
+			name: "only contact provided - email omitted",
 			paymentData: map[string]interface{}{
 				"amount": 10000,
 			},
@@ -3019,7 +3025,6 @@ func Test_addContactAndEmailToPaymentData_scenarios(t *testing.T) {
 			expectedResult: map[string]interface{}{
 				"amount":  10000,
 				"contact": "9876543210",
-				"email":   "9876543210@mcp.razorpay.com",
 			},
 		},
 		{
@@ -3036,7 +3041,7 @@ func Test_addContactAndEmailToPaymentData_scenarios(t *testing.T) {
 			},
 		},
 		{
-			name: "contact provided but email is empty - email generated",
+			name: "contact provided but email is empty - email omitted",
 			paymentData: map[string]interface{}{
 				"amount": 10000,
 			},
@@ -3047,7 +3052,6 @@ func Test_addContactAndEmailToPaymentData_scenarios(t *testing.T) {
 			expectedResult: map[string]interface{}{
 				"amount":  10000,
 				"contact": "9876543210",
-				"email":   "9876543210@mcp.razorpay.com",
 			},
 		},
 	}

--- a/pkg/razorpay/payments_test.go
+++ b/pkg/razorpay/payments_test.go
@@ -2,12 +2,14 @@ package razorpay
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	rzpsdk "github.com/razorpay/razorpay-go"
 	"github.com/razorpay/razorpay-go/constants"
 
 	"github.com/razorpay/razorpay-mcp-server/pkg/mcpgo"
@@ -3086,6 +3088,63 @@ func Test_addContactAndEmailToPaymentData_scenarios(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_InitiatePaymentRequestBody(t *testing.T) {
+	initiatePaymentPath := fmt.Sprintf(
+		"/%s%s/create/json",
+		constants.VERSION_V1,
+		constants.PAYMENT_URL,
+	)
+
+	t.Run("contact only omits email from request body", func(t *testing.T) {
+		var requestBody map[string]interface{}
+		server := httptest.NewServer(http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != initiatePaymentPath {
+					t.Errorf("unexpected path: %s", r.URL.Path)
+				}
+				if err := json.NewDecoder(r.Body).Decode(&requestBody); err != nil {
+					t.Errorf("failed to decode body: %v", err)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"razorpay_payment_id": "pay_test123",
+					"status":              "created",
+				})
+			},
+		))
+		defer server.Close()
+
+		obs := CreateTestObservability()
+		rzpClient := rzpsdk.NewClient("sample_key", "sample_secret")
+		rzpClient.Payment.Request.BaseURL = server.URL
+
+		tool := InitiatePayment(obs, rzpClient)
+		request := createMCPRequest(map[string]interface{}{
+			"amount":      float64(10000),
+			"order_id":    "order_test123",
+			"customer_id": "cust_test123",
+			"contact":     "9876543210",
+		})
+		result, err := tool.GetHandler()(context.Background(), request)
+
+		if err != nil {
+			t.Fatalf("handler error: %v", err)
+		}
+		if result == nil {
+			t.Fatal("expected non-nil result")
+		}
+		if _, hasEmail := requestBody["email"]; hasEmail {
+			t.Error("email must be omitted from payment request body")
+		}
+		if requestBody["contact"] != "9876543210" {
+			t.Errorf("expected contact in body, got %v", requestBody["contact"])
+		}
+		if !strings.Contains(result.Text, "warning") {
+			t.Error("expected warning in response when contact provided without email")
+		}
+	})
 }
 
 // Test_processPaymentResult_edgeCases


### PR DESCRIPTION
## Description
Fixes `initiate_payment` no longer fabricates customer emails when `email` is omitted.

Previously, `addContactAndEmailToPaymentData` invented `{contact}@mcp.razorpay.com` and sent it to the Razorpay payments API — a non-deliverable address that could cause receipt/notification issues.

**Changes:**
- **Omit email when absent** — only include `email` in the payment request when explicitly provided
- **Response warning** — when `contact` is provided without `email`, the response includes a `warning` field
- **Updated descriptions** — tool and `email` parameter docs clarify email is optional and must not be fabricated
- **README** — updated `initiate_payment` row

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, code improvements only)
- [x] Documentation update
- [ ] Performance improvement

## Testing
- [x] Manual testing
- [x] Added unit tests
- [x] Added integration tests (if applicable)
- [x] All tests pass locally

- Updated `Test_addContactAndEmailToPaymentData_scenarios` and `Test_InitiatePayment`
- Added `Test_InitiatePaymentRequestBody` to verify request body omits email
- Ran `go test ./pkg/razorpay/... -count=1` — all pass

## Checklist
- [x] I have followed the code style of this project
- [x] I have added comments to code where necessary, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary
- [x] I have verified that my changes do not introduce new warnings or errors
- [x] I have checked for and resolved any merge conflicts
- [x] I have considered the performance implications of my changes

## Additional Information
**Before:** `{ "contact": "9876543210" }` → API received `"email": "9876543210@mcp.razorpay.com"`

**After:** `{ "contact": "9876543210" }` → no email in request; response includes:
```json
"warning": "No email was provided; email was omitted from the payment request. Provide email for receipts and notifications."
```

**Behaviour change:** Workflows that relied on the auto-generated email will no longer receive one. Provide a real `email` when receipts or notifications are needed.