### PR TITLE
feat: add idempotency key support to create_refund

### DIFF
--- a/pkg/razorpay/refunds.go
+++ b/pkg/razorpay/refunds.go
@@ -9,6 +9,15 @@ import (
 	"github.com/razorpay/razorpay-mcp-server/pkg/observability"
 )
 
+// refundIdempotencyHeader carries the caller-supplied idempotency key on
+// the create-refund request.
+// https://razorpay.com/docs/api/refunds/normal-refunds-idempotent/
+const refundIdempotencyHeader = "X-Refund-Idempotency"
+
+// idempotencyKeyPattern is the key format Razorpay documents:
+// at least 10 characters of letters, numbers, hyphens and underscores.
+const idempotencyKeyPattern = `^[A-Za-z0-9_-]{10,}$`
+
 // CreateRefund returns a tool that creates a normal refund for a payment
 func CreateRefund(
 	obs *observability.Observability,
@@ -44,6 +53,17 @@ func CreateRefund(
 			mcpgo.Description("A unique identifier provided by you for "+
 				"your internal reference."),
 		),
+		mcpgo.WithString(
+			"idempotency_key",
+			mcpgo.Description("Makes this refund request retryable. "+
+				"Retrying with the same idempotency_key and an identical "+
+				"request body returns the original refund instead of "+
+				"creating a second one. Reuse the same value for every "+
+				"retry of the same refund; a new value creates a separate "+
+				"refund. At least 10 characters; letters, numbers, "+
+				"hyphens and underscores only."),
+			mcpgo.Pattern(idempotencyKeyPattern),
+		),
 	}
 
 	handler := func(
@@ -58,21 +78,30 @@ func CreateRefund(
 
 		payload := make(map[string]interface{})
 		data := make(map[string]interface{})
+		options := make(map[string]interface{})
 
 		validator := NewValidator(&r).
 			ValidateAndAddRequiredString(payload, "payment_id").
 			ValidateAndAddRequiredFloat(payload, "amount").
 			ValidateAndAddOptionalString(data, "speed").
 			ValidateAndAddOptionalString(data, "receipt").
-			ValidateAndAddOptionalMap(data, "notes")
+			ValidateAndAddOptionalMap(data, "notes").
+			ValidateAndAddOptionalString(options, "idempotency_key")
 
 		if result, err := validator.HandleErrorsIfAny(); result != nil {
 			return result, err
 		}
 
+		// extraHeaders stays nil when no key is supplied, so the request is
+		// unchanged for every existing caller.
+		var extraHeaders map[string]string
+		if key, ok := options["idempotency_key"].(string); ok && key != "" {
+			extraHeaders = map[string]string{refundIdempotencyHeader: key}
+		}
+
 		refund, err := client.Payment.Refund(
 			payload["payment_id"].(string),
-			int(payload["amount"].(float64)), data, nil)
+			int(payload["amount"].(float64)), data, extraHeaders)
 		if err != nil {
 			return mcpgo.NewToolResultError(
 				formatErrorMessage("creating refund failed", err)), nil

--- a/pkg/razorpay/refunds_test.go
+++ b/pkg/razorpay/refunds_test.go
@@ -1,11 +1,16 @@
 package razorpay
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
+	rzpsdk "github.com/razorpay/razorpay-go"
 	"github.com/razorpay/razorpay-go/constants"
 
 	"github.com/razorpay/razorpay-mcp-server/pkg/razorpay/mock"
@@ -139,6 +144,145 @@ func Test_CreateRefund(t *testing.T) {
 			runToolTest(t, tc, CreateRefund, "Refund")
 		})
 	}
+}
+
+// refundCapture records what the SDK actually put on the wire.
+type refundCapture struct {
+	// hasIdempotency distinguishes an absent header from an empty one,
+	// which Header.Get cannot.
+	hasIdempotency    bool
+	idempotencyHeader string
+	path              string
+	body              map[string]interface{}
+}
+
+// newRefundCaptureServer stands up a stub refund endpoint that records the
+// outgoing request. The shared mock package only replays responses, so a
+// dedicated stub is needed to assert on request headers.
+func newRefundCaptureServer(
+	t *testing.T,
+	got *refundCapture,
+) (*rzpsdk.Client, func()) {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			values := r.Header.Values(refundIdempotencyHeader)
+			got.hasIdempotency = len(values) > 0
+			got.idempotencyHeader = r.Header.Get(refundIdempotencyHeader)
+			got.path = r.URL.Path
+			_ = json.NewDecoder(r.Body).Decode(&got.body)
+
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":         "rfnd_FP8QHiV938haTz",
+				"entity":     "refund",
+				"amount":     float64(500100),
+				"payment_id": "pay_29QQoUBi66xm2f",
+				"status":     "processed",
+			})
+		}))
+
+	client := rzpsdk.NewClient("sample_key", "sample_secret")
+	// This Request object is shared by reference across all
+	// API resources in the client
+	client.Order.Request.BaseURL = srv.URL
+	client.Order.Request.HTTPClient = srv.Client()
+
+	return client, srv.Close
+}
+
+// The key must reach Razorpay as the X-Refund-Idempotency header, and
+// omitting it must leave the request exactly as it was before.
+func Test_CreateRefund_IdempotencyHeader(t *testing.T) {
+	tests := []struct {
+		name       string
+		request    map[string]interface{}
+		wantHeader string
+	}{
+		{
+			name: "key omitted sends no header",
+			request: map[string]interface{}{
+				"payment_id": "pay_29QQoUBi66xm2f",
+				"amount":     float64(500100),
+			},
+			wantHeader: "",
+		},
+		{
+			name: "key is forwarded verbatim",
+			request: map[string]interface{}{
+				"payment_id":      "pay_29QQoUBi66xm2f",
+				"amount":          float64(500100),
+				"idempotency_key": "op-7f3a91c2b4de",
+			},
+			wantHeader: "op-7f3a91c2b4de",
+		},
+		{
+			name: "empty key sends no header",
+			request: map[string]interface{}{
+				"payment_id":      "pay_29QQoUBi66xm2f",
+				"amount":          float64(500100),
+				"idempotency_key": "",
+			},
+			wantHeader: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var got refundCapture
+			client, closeFn := newRefundCaptureServer(t, &got)
+			defer closeFn()
+
+			tool := CreateRefund(CreateTestObservability(), client)
+			result, err := tool.GetHandler()(
+				context.Background(), createMCPRequest(tc.request))
+
+			assert.NoError(t, err)
+			assert.False(t, result.IsError, result.Text)
+
+			assert.Equal(t,
+				"/v1/payments/pay_29QQoUBi66xm2f/refund", got.path)
+			// An empty wantHeader means the header must be absent
+			// entirely, not merely empty.
+			assert.Equal(t, tc.wantHeader != "", got.hasIdempotency)
+			assert.Equal(t, tc.wantHeader, got.idempotencyHeader)
+			// The key travels as a header only. It must never be added
+			// to the refund request body.
+			assert.NotContains(t, got.body, "idempotency_key")
+		})
+	}
+}
+
+// Supplying a key must not disturb the refund body existing callers rely on,
+// and the key must not be echoed back in the tool result.
+func Test_CreateRefund_IdempotencyKeyLeavesBodyIntact(t *testing.T) {
+	var got refundCapture
+	client, closeFn := newRefundCaptureServer(t, &got)
+	defer closeFn()
+
+	tool := CreateRefund(CreateTestObservability(), client)
+	result, err := tool.GetHandler()(context.Background(), createMCPRequest(
+		map[string]interface{}{
+			"payment_id":      "pay_29QQoUBi66xm2f",
+			"amount":          float64(500100),
+			"speed":           "optimum",
+			"receipt":         "Receipt No. 31",
+			"notes":           map[string]interface{}{"reason": "returned"},
+			"idempotency_key": "op-7f3a91c2b4de",
+		}))
+
+	assert.NoError(t, err)
+	assert.False(t, result.IsError, result.Text)
+
+	assert.Equal(t, "op-7f3a91c2b4de", got.idempotencyHeader)
+	assert.Equal(t, float64(500100), got.body["amount"])
+	assert.Equal(t, "optimum", got.body["speed"])
+	assert.Equal(t, "Receipt No. 31", got.body["receipt"])
+	assert.Equal(t,
+		map[string]interface{}{"reason": "returned"}, got.body["notes"])
+	assert.NotContains(t, got.body, "idempotency_key")
+	assert.NotContains(t, result.Text, "op-7f3a91c2b4de")
 }
 
 func Test_FetchRefund(t *testing.T) {


### PR DESCRIPTION
## Description

Adds optional `idempotency_key` support to the `create_refund` MCP tool and forwards
it to Razorpay as the documented `X-Refund-Idempotency` header.

The Refund API supports this header for safely retrying the same refund request when
the caller may not have received the original response. The Go SDK already accepts
additional request headers on every resource method, but `create_refund` currently
passes `nil` and does not expose this capability.

When omitted, existing `create_refund` behavior is unchanged.

The documented key format (at least 10 characters; letters, numbers, hyphens and
underscores) is declared on the parameter schema via `mcpgo.Pattern`, consistent with
how other tools declare string formats. Razorpay remains the authority on key
validity.

## Related Issues

N/A

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- [x] Added unit tests
- [x] All tests pass locally

Added coverage for:

- forwarding `X-Refund-Idempotency` when `idempotency_key` is provided
- not sending the header when it is omitted
- preserving existing refund arguments (`amount`, `speed`, `receipt`, `notes`)

Header presence is asserted via `Header.Values` rather than `Header.Get`, so an
absent header is distinguished from a present-but-empty one.

Also verified locally:

- `go build ./...`
- `go test ./...`
- `go vet ./...`
- `gofmt`
- `golangci-lint run` (v1.64.8, matching the repo's pinned version)

`go test -race` was not run locally because the local cgo toolchain is 32-bit.
The change introduces no concurrency. Repository CI is currently awaiting
maintainer approval for first-time-contributor workflow execution.

## Why not `receipt`?

`receipt` can prevent reuse of the same receipt on a payment, but it does not provide
the same retry/replay behavior.

In Razorpay Test Mode, retrying a completed refund with the same
`X-Refund-Idempotency` value returned the original refund object, including its
refund ID. Reusing a `receipt` instead returned a duplicate-receipt error.

This distinction matters when a client does not receive the original refund response
and needs to recover the result of that request.

## Limitations

This change only exposes Razorpay's existing provider-level idempotency mechanism.
It does not provide durable logical-operation identity.

Callers remain responsible for reusing the same idempotency key for retries that
represent the same logical refund operation. Supplying a new key represents a new
request to Razorpay.

`idempotentHint` is intentionally not changed. A tool whose caller may omit the key,
or supply a new one per invocation, is not semantically idempotent.

## Checklist

- [x] I have followed the code style of this project
- [x] I have added comments to code where necessary, particularly in hard-to-understand areas
- [ ] I have updated the documentation where necessary — the README tool table does not enumerate per-tool parameters, so no documentation change appeared necessary. Happy to add one if you would prefer.
- [x] I have verified that my changes do not introduce new warnings or errors
- [x] I have checked for and resolved any merge conflicts
- [x] I have considered the performance implications of my changes

## Additional Information

Production change is +31/−2 lines in `pkg/razorpay/refunds.go`. No new dependencies.
The branch is rebased on current `main` (`7950d51`).

### Interaction with #109

PR #109 changes `create_refund` so full refunds may use a direct `Request.Post`
path while partial refunds continue through `Payment.Refund`.

This PR is currently based on `main` before #109. If #109 lands first, this patch
will need to ensure `X-Refund-Idempotency` is forwarded through both refund paths.
Happy to rebase once #109 is merged.
