### PR TITLE
fix: update mcpgo README examples to match current API

### DIFF
--- a/pkg/mcpgo/README.md
+++ b/pkg/mcpgo/README.md
@@ -43,9 +43,13 @@ The package also provides functions for creating tool results:
 
 ## Usage Example
 
+`CallToolRequest.Arguments` is typed as `any`; type-assert it to
+`map[string]interface{}` before indexing (same pattern as
+`extractValueGeneric` in `pkg/razorpay/tools_params.go`).
+
 ```go
 // Create a server
-server := mcpgo.NewServer(
+server := mcpgo.NewMcpServer(
     "my-server",
     "1.0.0",
     mcpgo.WithLogging(),
@@ -64,14 +68,24 @@ tool := mcpgo.NewTool(
         ),
     },
     func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.ToolResult, error) {
-        // Extract parameter value
-        param1Value, ok := req.Arguments["param1"]
+        // Arguments is any — assert to map before indexing
+        args, ok := req.Arguments.(map[string]interface{})
+        if !ok {
+            return mcpgo.NewToolResultError("invalid arguments type"), nil
+        }
+
+        param1Value, ok := args["param1"]
         if !ok {
             return mcpgo.NewToolResultError("Missing required parameter: param1"), nil
         }
-        
+
+        param1Str, ok := param1Value.(string)
+        if !ok {
+            return mcpgo.NewToolResultError("param1 must be a string"), nil
+        }
+
         // Process and return result
-        return mcpgo.NewToolResultText("Result: " + param1Value.(string)), nil
+        return mcpgo.NewToolResultText("Result: " + param1Str), nil
     },
 )
 
@@ -96,7 +110,7 @@ Here's how we use this package in the Razorpay MCP server to create a payment fe
 ```go
 // FetchPayment returns a tool that fetches payment details using payment_id
 func FetchPayment(
-    log *slog.Logger,
+    obs *observability.Observability,
     client *rzpsdk.Client,
 ) mcpgo.Tool {
     parameters := []mcpgo.ToolParameter{
@@ -111,7 +125,12 @@ func FetchPayment(
         ctx context.Context,
         r mcpgo.CallToolRequest,
     ) (*mcpgo.ToolResult, error) {
-        arg, ok := r.Arguments["payment_id"]
+        args, ok := r.Arguments.(map[string]interface{})
+        if !ok {
+            return mcpgo.NewToolResultError("invalid arguments type"), nil
+        }
+
+        arg, ok := args["payment_id"]
         if !ok {
             return mcpgo.NewToolResultError(
                 "payment id is a required field"), nil


### PR DESCRIPTION
## Description

Fixes non-compiling code snippets in `pkg/mcpgo/README.md`:

- **Usage example** — `CallToolRequest.Arguments` is `any`; examples now type-assert to `map[string]interface{}` before indexing (matching `extractValueGeneric` in `tools_params.go`). Also corrected `NewServer` → `NewMcpServer`.
- **Real-world example** — Replaced removed `log *slog.Logger` signature with `obs *observability.Observability`, and added the same `Arguments` type-assertion pattern for `payment_id`.

Added a short note above the usage example explaining the `Arguments` typing requirement.

Documentation-only change — no runtime behavior changes.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, code improvements only)
- [x] Documentation update
- [ ] Performance improvement

## Testing

- [x] Manual testing *(verified snippets match current API: `CallToolRequest.Arguments` as `any`, `NewMcpServer`, `obs *observability.Observability`)*
- [ ] Added unit tests *(N/A — README-only change)*
- [ ] Added integration tests (if applicable) *(N/A)*
- [x] All tests pass locally *(no code changes; existing tests unaffected)*

## Checklist

- [x] I have followed the code style of this project
- [x] I have added comments to code where necessary, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary
- [x] I have verified that my changes do not introduce new warnings or errors
- [x] I have checked for and resolved any merge conflicts
- [x] I have considered the performance implications of my changes

## Additional Information

The README examples previously would fail to compile because:
1. `req.Arguments["param1"]` is invalid when `Arguments` is `any`
2. `FetchPayment` no longer accepts `*slog.Logger` — tools now take `*observability.Observability`