### PR TITLE
fix: update authoring guide

### DIFF
--- a/pkg/razorpay/README.md
+++ b/pkg/razorpay/README.md
@@ -11,17 +11,19 @@ This guide explains how to add new Razorpay API tools to the MCP server.
 1. Locate the API documentation at https://razorpay.com/docs/api/
 2. Identify the equivalent function call for the API in the razorpay go sdk.
 3. Create a new tool function in the appropriate file (or create a new file for a new resource type). Add validations for mandatory fields and call the sdk
-5. Register the tool in `server.go`
+5. Register the tool in `tools.go`
 6. Update "Available Tools" section in the main README.md
 
 ### Tool Structure
 
-Add the tool definition inside pkg/razorpay's resource file. You can define a new tool using this following template:
+Add the tool definition inside pkg/razorpay's resource file. Tool functions take
+`*observability.Observability` (not `*slog.Logger`). You can define a new tool
+using this following template:
 
 ```go
 // ToolName returns a tool that [description of what it does]
 func ToolName(
-    log *slog.Logger,
+    obs *observability.Observability,
     client *rzpsdk.Client,
 ) mcpgo.Tool {
     parameters := []mcpgo.ToolParameter{
@@ -98,8 +100,8 @@ v.ValidateAndAddRequiredString(payload, "id").
 v.ValidateAndAddPagination(payload).
   ValidateAndAddExpand(payload)
 
-// Check for validation errors
-if result, err := validator.HandleErrorsIfAny(); result != nil {
+// Check for validation errors (receiver is v, not validator)
+if result, err := v.HandleErrorsIfAny(); result != nil {
 	return result, err
 }
 
@@ -111,7 +113,7 @@ if result, err := validator.HandleErrorsIfAny(); result != nil {
 ```go
 // FetchResource returns a tool that fetches a resource by ID
 func FetchResource(
-    log *slog.Logger,
+    obs *observability.Observability,
     client *rzpsdk.Client,
 ) mcpgo.Tool {
     parameters := []mcpgo.ToolParameter{
@@ -132,7 +134,7 @@ func FetchResource(
             ValidateAndAddRequiredString(payload, "id")
         
         // Check for validation errors
-        if result, err := validator.HandleErrorsIfAny(); result != nil {
+        if result, err := v.HandleErrorsIfAny(); result != nil {
 			return result, err
 		}
 
@@ -161,7 +163,7 @@ func FetchResource(
 ```go
 // CreateResource returns a tool that creates a new resource
 func CreateResource(
-    log *slog.Logger,
+    obs *observability.Observability,
     client *rzpsdk.Client,
 ) mcpgo.Tool {
     parameters := []mcpgo.ToolParameter{
@@ -193,7 +195,7 @@ func CreateResource(
             ValidateAndAddOptionalString(data, "description")
         
         // Check for validation errors
-        if result, err := validator.HandleErrorsIfAny(); result != nil {
+        if result, err := v.HandleErrorsIfAny(); result != nil {
 			return result, err
 		}
 
@@ -223,7 +225,7 @@ Add your tool to the appropriate toolset in the `NewToolSets` function in [`pkg/
 ```go
 // NewToolSets creates and configures all available toolsets
 func NewToolSets(
-    log *slog.Logger,
+    obs *observability.Observability,
     client *rzpsdk.Client,
     enabledToolsets []string,
     readOnly bool,
@@ -234,7 +236,7 @@ func NewToolSets(
     // Create toolsets
     payments := toolsets.NewToolset("payments", "Razorpay Payments related tools").
         AddReadTools(
-            FetchPayment(log, client),
+            FetchPayment(obs, client),
             // Add your read-only payment tool here
         ).
         AddWriteTools(
@@ -245,21 +247,21 @@ func NewToolSets(
         "payment_links",
         "Razorpay Payment Links related tools").
         AddReadTools(
-            FetchPaymentLink(log, client),
+            FetchPaymentLink(obs, client),
             // Add your read-only payment link tool here
         ).
         AddWriteTools(
-            CreatePaymentLink(log, client),
+            CreatePaymentLink(obs, client),
             // Add your write payment link tool here
         )
 
     orders := toolsets.NewToolset("orders", "Razorpay Orders related tools").
         AddReadTools(
-            FetchOrder(log, client),
+            FetchOrder(obs, client),
             // Add your read-only order tool here
         ).
         AddWriteTools(
-            CreateOrder(log, client),
+            CreateOrder(obs, client),
             // Add your write order tool here
         )
 
@@ -267,10 +269,10 @@ func NewToolSets(
     /*
     newResource := toolsets.NewToolset("new_resource", "Razorpay New Resource related tools").
         AddReadTools(
-            FetchNewResource(log, client),
+            FetchNewResource(obs, client),
         ).
         AddWriteTools(
-            CreateNewResource(log, client),
+            CreateNewResource(obs, client),
         )
     toolsetGroup.AddToolset(newResource)
     */
@@ -394,7 +396,7 @@ After adding a new tool, Update the "Available Tools" section in the README.md i
 3. **Validation**: Always validate required parameters and collect all validation errors before returning using fluent validator pattern.
    - Use the `NewValidator` to create a validator
    - Chain validation methods (`ValidateAndAddRequiredString`, etc.)
-   - Return formatted errors with `HandleErrorsIfAny()`
+   - Return formatted errors with `v.HandleErrorsIfAny()`
 
 4. **Documentation**: Describe all the parameters clearly for the LLMs to understand.
 

--- a/pkg/razorpay/authoring_guide_test.go
+++ b/pkg/razorpay/authoring_guide_test.go
@@ -1,0 +1,95 @@
+package razorpay
+
+import (
+	"bufio"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// staleAuthoringGuidePatterns are templates that no longer match the codebase.
+var staleAuthoringGuidePatterns = []*regexp.Regexp{
+	regexp.MustCompile(`log \*slog\.Logger`),
+	regexp.MustCompile(`\(log, client\)`),
+	regexp.MustCompile(`Register the tool in ` + "`server.go`"),
+}
+
+func TestAuthoringGuide_NoStaleToolSignatures(t *testing.T) {
+	lines, err := readREADMELines()
+	require.NoError(t, err)
+
+	for lineNum, line := range lines {
+		for _, pattern := range staleAuthoringGuidePatterns {
+			if pattern.MatchString(line) {
+				t.Errorf(
+					"README.md:%d: stale authoring guide pattern %q: %s",
+					lineNum+1,
+					pattern.String(),
+					strings.TrimSpace(line),
+				)
+			}
+		}
+	}
+}
+
+func TestAuthoringGuide_ValidatorReceiverMatchesVariable(t *testing.T) {
+	lines, err := readREADMELines()
+	require.NoError(t, err)
+
+	inCodeBlock := false
+	usesVValidator := false
+
+	for lineNum, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "```") {
+			inCodeBlock = !inCodeBlock
+			usesVValidator = false
+			continue
+		}
+		if !inCodeBlock {
+			continue
+		}
+
+		if strings.Contains(line, "v := NewValidator") ||
+			strings.Contains(line, "v := NewValidator(&r)") {
+			usesVValidator = true
+		}
+
+		if strings.Contains(line, "validator.HandleErrorsIfAny()") &&
+			usesVValidator {
+			t.Errorf(
+				"README.md:%d: use v.HandleErrorsIfAny() when receiver is v",
+				lineNum+1,
+			)
+		}
+	}
+}
+
+func TestAuthoringGuide_DocumentsCurrentToolSignature(t *testing.T) {
+	content, err := os.ReadFile("README.md")
+	require.NoError(t, err)
+
+	text := string(content)
+	assert.Contains(t, text, "obs *observability.Observability")
+	assert.Contains(t, text, "v.HandleErrorsIfAny()")
+}
+
+func readREADMELines() ([]string, error) {
+	file, err := os.Open("README.md")
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var lines []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+
+	return lines, scanner.Err()
+}


### PR DESCRIPTION
## Description

Fixes outdated templates in `pkg/razorpay/README.md` that caused compile errors for new contributors:

- **Tool function signatures** — replaced `log *slog.Logger` with `obs *observability.Observability` in the tool template, GET/POST examples, and `NewToolSets` registration snippet
- **Tool registration calls** — updated `(log, client)` → `(obs, client)` across all registration examples
- **Validator receiver** — fixed `validator.HandleErrorsIfAny()` → `v.HandleErrorsIfAny()` in Parameter Validation, GET, and POST examples
- **Quick Start** — corrected registration step from `server.go` → `tools.go`

Also adds `authoring_guide_test.go` regression tests to guard against future drift, and documents conventions in Best Practices.

Documentation-only change — no runtime behavior changes.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, code improvements only)
- [x] Documentation update
- [ ] Performance improvement

## Testing

- [x] Manual testing *(verified snippets match current API in `tools.go` and validator usage)*
- [x] Added unit tests (`authoring_guide_test.go`)
- [ ] Added integration tests (if applicable) *(N/A — README-only change)*
- [x] All tests pass locally

**Commands run:**
- `go test ./pkg/razorpay/... -count=1`
- `golangci-lint run ./pkg/razorpay/...`

## Checklist

- [x] I have followed the code style of this project
- [x] I have added comments to code where necessary, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary
- [x] I have verified that my changes do not introduce new warnings or errors
- [x] I have checked for and resolved any merge conflicts
- [x] I have considered the performance implications of my changes

## Additional Information

Copy-pasting the old templates would fail to compile because:
1. Tools now take `*observability.Observability`, not `*slog.Logger`
2. Examples assigned the validator to `v` but called `validator.HandleErrorsIfAny()` on an undefined variable

Production tool code correctly uses `validator := NewValidator(...)` where the variable is named `validator`; only the **authoring guide examples** had the mismatched `v` / `validator` naming.