### PR TITLE
fix: update tool documentation and generator templates

### DIFF
--- a/.agents/skills/razorpay-mcp-tool-gen/SKILL.md
+++ b/.agents/skills/razorpay-mcp-tool-gen/SKILL.md
@@ -54,7 +54,18 @@ Map each parameter to a validator type:
 | number (float) | `mcpgo.WithNumber` | `ValidateAndAddRequiredFloat` / `ValidateAndAddOptionalFloat` |
 | boolean | `mcpgo.WithBoolean` | `ValidateAndAddRequiredBool` / `ValidateAndAddOptionalBool` |
 | object | `mcpgo.WithObject` | `ValidateAndAddRequiredMap` / `ValidateAndAddOptionalMap` |
-| array | `mcpgo.WithArray` | `ValidateAndAddRequiredArray` / `ValidateAndAddOptionalArray` |
+| array | `mcpgo.WithArray` + **`mcpgo.Items(...)`** (required) | `ValidateAndAddRequiredArray` / `ValidateAndAddOptionalArray` |
+
+**Array parameters MUST include `mcpgo.Items(...)`** with the element schema.
+Without it the published MCP schema is invalid and clients cannot use the tool.
+
+```go
+mcpgo.WithArray(
+    "tags",
+    mcpgo.Description("List of tag strings"),
+    mcpgo.Items(map[string]interface{}{"type": "string"}),
+)
+```
 
 For nested objects (e.g., `customer.name` flattened to `customer_name`), use `ValidateAndAddOptionalStringToPath`.
 

--- a/.claude/skills/razorpay-mcp-tool-gen/SKILL.md
+++ b/.claude/skills/razorpay-mcp-tool-gen/SKILL.md
@@ -54,7 +54,18 @@ Map each parameter to a validator type:
 | number (float) | `mcpgo.WithNumber` | `ValidateAndAddRequiredFloat` / `ValidateAndAddOptionalFloat` |
 | boolean | `mcpgo.WithBoolean` | `ValidateAndAddRequiredBool` / `ValidateAndAddOptionalBool` |
 | object | `mcpgo.WithObject` | `ValidateAndAddRequiredMap` / `ValidateAndAddOptionalMap` |
-| array | `mcpgo.WithArray` | `ValidateAndAddRequiredArray` / `ValidateAndAddOptionalArray` |
+| array | `mcpgo.WithArray` + **`mcpgo.Items(...)`** (required) | `ValidateAndAddRequiredArray` / `ValidateAndAddOptionalArray` |
+
+**Array parameters MUST include `mcpgo.Items(...)`** with the element schema.
+Without it the published MCP schema is invalid and clients cannot use the tool.
+
+```go
+mcpgo.WithArray(
+    "tags",
+    mcpgo.Description("List of tag strings"),
+    mcpgo.Items(map[string]interface{}{"type": "string"}),
+)
+```
 
 For nested objects (e.g., `customer.name` flattened to `customer_name`), use `ValidateAndAddOptionalStringToPath`.
 

--- a/.cursor/skills/razorpay-mcp-tool-gen/SKILL.md
+++ b/.cursor/skills/razorpay-mcp-tool-gen/SKILL.md
@@ -54,7 +54,18 @@ Map each parameter to a validator type:
 | number (float) | `mcpgo.WithNumber` | `ValidateAndAddRequiredFloat` / `ValidateAndAddOptionalFloat` |
 | boolean | `mcpgo.WithBoolean` | `ValidateAndAddRequiredBool` / `ValidateAndAddOptionalBool` |
 | object | `mcpgo.WithObject` | `ValidateAndAddRequiredMap` / `ValidateAndAddOptionalMap` |
-| array | `mcpgo.WithArray` | `ValidateAndAddRequiredArray` / `ValidateAndAddOptionalArray` |
+| array | `mcpgo.WithArray` + **`mcpgo.Items(...)`** (required) | `ValidateAndAddRequiredArray` / `ValidateAndAddOptionalArray` |
+
+**Array parameters MUST include `mcpgo.Items(...)`** with the element schema.
+Without it the published MCP schema is invalid and clients cannot use the tool.
+
+```go
+mcpgo.WithArray(
+    "tags",
+    mcpgo.Description("List of tag strings"),
+    mcpgo.Items(map[string]interface{}{"type": "string"}),
+)
+```
 
 For nested objects (e.g., `customer.name` flattened to `customer_name`), use `ValidateAndAddOptionalStringToPath`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,18 @@ Map each parameter to a validator type:
 | number (float) | `mcpgo.WithNumber` | `ValidateAndAddRequiredFloat` / `ValidateAndAddOptionalFloat` |
 | boolean | `mcpgo.WithBoolean` | `ValidateAndAddRequiredBool` / `ValidateAndAddOptionalBool` |
 | object | `mcpgo.WithObject` | `ValidateAndAddRequiredMap` / `ValidateAndAddOptionalMap` |
-| array | `mcpgo.WithArray` | `ValidateAndAddRequiredArray` / `ValidateAndAddOptionalArray` |
+| array | `mcpgo.WithArray` + **`mcpgo.Items(...)`** (required) | `ValidateAndAddRequiredArray` / `ValidateAndAddOptionalArray` |
+
+**Array parameters MUST include `mcpgo.Items(...)`** with the element schema.
+Without it the published MCP schema is invalid and clients cannot use the tool.
+
+```go
+mcpgo.WithArray(
+    "tags",
+    mcpgo.Description("List of tag strings"),
+    mcpgo.Items(map[string]interface{}{"type": "string"}),
+)
+```
 
 For nested objects (e.g., `customer.name` flattened to `customer_name`), use `ValidateAndAddOptionalStringToPath`.
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Currently, the Razorpay MCP Server provides the following tools:
 | `resend_otp`                        | Resend OTP if the previous one was not received or expired | [Payment](https://github.com/razorpay/razorpay-go/blob/master/documents/payment.md#otp-resend) | ✅ |
 | `submit_otp`                        | Verify and submit OTP to complete payment authentication | [Payment](https://github.com/razorpay/razorpay-go/blob/master/documents/payment.md#otp-submit) | ✅ |
 | `create_payment_link`                | Creates a new payment link (standard)                  | [Payment Link](https://razorpay.com/docs/api/payments/payment-links/create-standard) | ✅ |
-| `create_payment_link_upi`            | Creates a new UPI payment link                         | [Payment Link](https://razorpay.com/docs/api/payments/payment-links/create-upi) | ✅ |
+| `payment_link_upi_create`            | Creates a new UPI payment link                         | [Payment Link](https://razorpay.com/docs/api/payments/payment-links/create-upi) | ✅ |
 | `fetch_all_payment_links`            | Fetch all the payment links                            | [Payment Link](https://razorpay.com/docs/api/payments/payment-links/fetch-all-standard) | ✅ |
 | `fetch_payment_link`                 | Fetch details of a payment link                        | [Payment Link](https://razorpay.com/docs/api/payments/payment-links/fetch-id-standard/) | ✅ |
-| `send_payment_link`                  | Send a payment link via SMS or email.                  | [Payment Link](https://razorpay.com/docs/api/payments/payment-links/resend) | ✅ |
+| `payment_link_notify`                | Send a payment link via SMS or email.                  | [Payment Link](https://razorpay.com/docs/api/payments/payment-links/resend) | ✅ |
 | `update_payment_link`                | Updates a new standard payment link                    | [Payment Link](https://razorpay.com/docs/api/payments/payment-links/update-standard) | ✅ |
 | `create_order`                       | Creates an order                                       | [Order](https://razorpay.com/docs/api/orders/create/) | ✅ |
 | `fetch_order`                        | Fetch order with ID                                    | [Order](https://razorpay.com/docs/api/orders/fetch-with-id) | ✅ |
@@ -53,7 +53,7 @@ Currently, the Razorpay MCP Server provides the following tools:
 | `fetch_all_instant_settlements`      | Fetch all instant settlements                          | [Settlement](https://razorpay.com/docs/api/settlements/instant/fetch-all) | ✅ |
 | `fetch_instant_settlement_with_id`   | Fetch instant settlement with ID                       | [Settlement](https://razorpay.com/docs/api/settlements/instant/fetch-with-id) | ✅ |
 | `fetch_all_payouts`                  | Fetch all payout details with A/c number               | [Payout](https://razorpay.com/docs/api/x/payouts/fetch-all/) | ✅ |
-| `fetch_payout_by_id`                 | Fetch the payout details with payout ID                | [Payout](https://razorpay.com/docs/api/x/payouts/fetch-with-id) | ✅ |
+| `fetch_payout_with_id`               | Fetch the payout details with payout ID                | [Payout](https://razorpay.com/docs/api/x/payouts/fetch-with-id) | ✅ |
 | `fetch_tokens`     | Get all saved payment methods by customer ID or contact number | [Token](https://razorpay.com/docs/payments/payment-gateway/s2s-integration/recurring-payments/cards/tokens/) | ✅ |
 | `revoke_token`     | Revoke a saved payment method (token) for a customer   | [Token](https://razorpay.com/docs/payments/payment-gateway/s2s-integration/recurring-payments/upi-otm/collect/tokens/#24-cancel-token) | ✅ |
 | `create_registration_link`           | Create a registration link (auth link) for subscription registration | [Registration Link](https://razorpay.com/docs/api/payments/recurring-payments/registration-link/) | ❌ |

--- a/pkg/razorpay/README.md
+++ b/pkg/razorpay/README.md
@@ -76,6 +76,15 @@ Available parameter types:
 - `WithNumber`: For numeric values
 - `WithBoolean`: For boolean values
 - `WithObject`: For nested objects
+- `WithArray`: For arrays — **must** include `mcpgo.Items(...)` with the element schema
+
+```go
+mcpgo.WithArray(
+    "tags",
+    mcpgo.Description("List of tag strings"),
+    mcpgo.Items(map[string]interface{}{"type": "string"}),
+)
+```
 
 ### Parameter Validation
 

--- a/pkg/razorpay/payouts.go
+++ b/pkg/razorpay/payouts.go
@@ -9,7 +9,7 @@ import (
 	"github.com/razorpay/razorpay-mcp-server/pkg/observability"
 )
 
-// FetchPayoutByID returns a tool that fetches a payout by its ID
+// FetchPayout returns a tool that fetches a payout by its ID
 func FetchPayout(
 	obs *observability.Observability,
 	client *rzpsdk.Client,

--- a/pkg/razorpay/tool_docs_test.go
+++ b/pkg/razorpay/tool_docs_test.go
@@ -1,0 +1,115 @@
+package razorpay
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("go.mod not found")
+		}
+		dir = parent
+	}
+}
+
+func TestToolGeneratorDocs_requireArrayItemsRule(t *testing.T) {
+	root := repoRoot(t)
+	docs := []string{
+		"AGENTS.md",
+		filepath.Join(".cursor", "skills", "razorpay-mcp-tool-gen", "SKILL.md"),
+		filepath.Join(".claude", "skills", "razorpay-mcp-tool-gen", "SKILL.md"),
+		filepath.Join(".agents", "skills", "razorpay-mcp-tool-gen", "SKILL.md"),
+	}
+
+	for _, doc := range docs {
+		t.Run(doc, func(t *testing.T) {
+			content, err := os.ReadFile(filepath.Join(root, doc))
+			require.NoError(t, err)
+			text := string(content)
+			assert.Contains(t, text, "mcpgo.Items")
+			assert.Contains(t, text, "MUST include `mcpgo.Items")
+		})
+	}
+}
+
+func TestREADME_toolNamesMatchRegisteredTools(t *testing.T) {
+	root := repoRoot(t)
+	readmePath := filepath.Join(root, "README.md")
+	content, err := os.ReadFile(readmePath)
+	require.NoError(t, err)
+
+	readmeTools := parseREADMEToolNames(string(content))
+	require.NotEmpty(t, readmeTools)
+
+	registered := collectRegisteredToolNames(t, root)
+	for _, name := range readmeTools {
+		assert.Contains(t, registered, name,
+			"README lists tool %q that is not registered in code", name)
+	}
+}
+
+func parseREADMEToolNames(readme string) []string {
+	const section = "## Available Tools"
+	start := strings.Index(readme, section)
+	if start == -1 {
+		return nil
+	}
+
+	sectionText := readme[start:]
+	if end := strings.Index(sectionText, "\n## Use Cases"); end != -1 {
+		sectionText = sectionText[:end]
+	}
+
+	re := regexp.MustCompile(`\|\s*` + "`" + `([a-z_]+)` + "`")
+	matches := re.FindAllStringSubmatch(sectionText, -1)
+	names := make([]string, 0, len(matches))
+	for _, match := range matches {
+		names = append(names, match[1])
+	}
+	return names
+}
+
+func collectRegisteredToolNames(t *testing.T, root string) map[string]struct{} {
+	t.Helper()
+
+	toolDirs := []string{
+		filepath.Join(root, "pkg", "razorpay"),
+		filepath.Join(root, "pkg", "razorpay", "integrations"),
+	}
+	re := regexp.MustCompile(`NewTool\(\s*"([a-z_]+)"`)
+
+	registered := make(map[string]struct{})
+	for _, dir := range toolDirs {
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") ||
+				strings.HasSuffix(entry.Name(), "_test.go") {
+				continue
+			}
+			fileContent, readErr := os.ReadFile(filepath.Join(dir, entry.Name()))
+			require.NoError(t, readErr)
+			for _, match := range re.FindAllStringSubmatch(string(fileContent), -1) {
+				registered[match[1]] = struct{}{}
+			}
+		}
+	}
+	return registered
+}


### PR DESCRIPTION
## Description

Fixes two documentation issues that caused bot-generated tools and README consumers to fail:

**Tool generator — array `Items` rule**  
Updated `AGENTS.md`, all three `SKILL.md` copies, and `pkg/razorpay/README.md` to require `mcpgo.Items(...)` on every array parameter, with an example. Without this, generated tools can publish invalid MCP schemas.

**README tool name mismatches**  
Reconciled the README "Available Tools" table to match registered tool names (non-breaking — no tool renames):

| README (before) | README (now) |
|---|---|
| `create_payment_link_upi` | `payment_link_upi_create` |
| `send_payment_link` | `payment_link_notify` |
| `fetch_payout_by_id` | `fetch_payout_with_id` |

Also corrected the `FetchPayout` function comment in `payouts.go` (was `FetchPayoutByID`).

Added regression tests in `pkg/razorpay/tool_docs_test.go`.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, code improvements only)
- [x] Documentation update
- [ ] Performance improvement

## Testing

- [x] Manual testing — verified doc content and regression tests cover README/tool-name alignment
- [x] Added unit tests
- [ ] Added integration tests (if applicable) — N/A
- [x] All tests pass locally — `go test ./... -count=1`

**New tests:**
- `TestToolGeneratorDocs_requireArrayItemsRule` — all four generator docs mention `mcpgo.Items`
- `TestREADME_toolNamesMatchRegisteredTools` — every README tool name exists in code

## Checklist

- [x] I have followed the code style of this project
- [x] I have added comments to code where necessary, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary
- [x] I have verified that my changes do not introduce new warnings or errors
- [x] I have checked for and resolved any merge conflicts
- [x] I have considered the performance implications of my changes

## Additional Information

**Design choice:** README was updated to match shipped tool names rather than renaming tools, since renaming registered MCP tools is a breaking change for existing clients.

**Note:** Three tool names (`payment_link_upi_create`, `payment_link_notify`, `fetch_payout_with_id`) do not follow the `create_*` / `fetch_*` convention. Renaming them can be a follow-up if maintainers want consistency.