### PR TITLE
fix: correct recurring payment API selection

### DIFF
--- a/pkg/razorpay/payments.go
+++ b/pkg/razorpay/payments.go
@@ -685,12 +685,13 @@ func createPaymentWithParams(
 	paymentDataPtr := buildPaymentData(params, currency, customerID)
 	paymentData := *paymentDataPtr
 
-	// Determine if recurring payment API should be used
-	// Non-INR currency + token + recurring flag = use recurring API
+	// Route INR recurring subsequent payments to /payments/create/recurring.
+	// Razorpay docs use this endpoint for UPI/card/NACH mandate debits (INR).
+	// Non-INR recurring requests fall back to the S2S JSON create/json flow.
 	useRecurringAPI := false
 	if recurring, ok := params["recurring"].(bool); ok && recurring {
 		if tokenStr, ok := params["token"].(string); ok && tokenStr != "" {
-			useRecurringAPI = currency != "INR"
+			useRecurringAPI = currency == "INR"
 		}
 	}
 
@@ -767,8 +768,10 @@ func InitiatePayment(
 		),
 		mcpgo.WithBoolean(
 			"recurring",
-			mcpgo.Description("Set this to true for recurring payments like "+
-				"single block multiple debit."),
+			mcpgo.Description("Set to true for subsequent recurring debits "+
+				"(e.g. UPI single-block-multiple-debit mandates). "+
+				"When true with a token and INR currency, uses the "+
+				"/payments/create/recurring API."),
 		),
 		mcpgo.WithString(
 			"force_terminal_id",
@@ -854,6 +857,8 @@ func InitiatePayment(
 		"Initiate a payment using the S2S JSON v1 flow. "+
 			"Required parameters: amount and order_id. "+
 			"For saved payment methods, provide token. "+
+			"For INR recurring subsequent debits, set recurring=true with "+
+			"a token to use /payments/create/recurring. "+
 			"For UPI collect flow, provide 'vpa' parameter "+
 			"which automatically sets UPI with flow='collect' and expiry_time='6'. "+
 			"For UPI intent flow, set 'upi_intent=true' parameter "+

--- a/pkg/razorpay/payments_test.go
+++ b/pkg/razorpay/payments_test.go
@@ -1127,7 +1127,7 @@ func Test_InitiatePayment(t *testing.T) {
 			ExpectedErrMsg: "invalid parameter type: upi_intent",
 		},
 		{
-			Name: "recurring payment with INR currency uses regular flow",
+			Name: "recurring payment with INR currency uses recurring flow",
 			Request: map[string]interface{}{
 				"amount":            10000,
 				"currency":          "INR",
@@ -1151,7 +1151,7 @@ func Test_InitiatePayment(t *testing.T) {
 				}
 				return mock.NewHTTPClient(
 					mock.Endpoint{
-						Path:     initiatePaymentPath,
+						Path:     recurringPaymentPath,
 						Method:   "POST",
 						Response: successPaymentWithTerminalResp,
 					},
@@ -1182,7 +1182,7 @@ func Test_InitiatePayment(t *testing.T) {
 		},
 		{
 			Name: "recurring payment with non-INR currency and token " +
-				"uses recurring flow",
+				"uses JSON flow",
 			Request: map[string]interface{}{
 				"amount":            10000,
 				"currency":          "USD",
@@ -1206,7 +1206,7 @@ func Test_InitiatePayment(t *testing.T) {
 				}
 				return mock.NewHTTPClient(
 					mock.Endpoint{
-						Path:     recurringPaymentPath,
+						Path:     initiatePaymentPath,
 						Method:   "POST",
 						Response: successPaymentWithTerminalResp,
 					},
@@ -1299,6 +1299,129 @@ func Test_InitiatePayment(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
 			runToolTest(t, tc, InitiatePayment, "Payment Initiation")
+		})
+	}
+}
+
+func Test_createPaymentWithParams_recurringAPIRouting(t *testing.T) {
+	initiatePaymentPath := fmt.Sprintf(
+		"/%s%s/create/json",
+		constants.VERSION_V1,
+		constants.PAYMENT_URL,
+	)
+
+	recurringPaymentPath := fmt.Sprintf(
+		"/%s%s/create/recurring",
+		constants.VERSION_V1,
+		constants.PAYMENT_URL,
+	)
+
+	successResp := map[string]interface{}{
+		"razorpay_payment_id": "pay_test123",
+		"status":              "created",
+	}
+
+	tests := []struct {
+		name            string
+		params          map[string]interface{}
+		currency        string
+		expectRecurring bool
+	}{
+		{
+			name: "INR recurring with token uses recurring API",
+			params: map[string]interface{}{
+				"amount":    10000,
+				"order_id":  "order_129837127313912",
+				"token":     "token_MT48CvBhIC98MQ",
+				"recurring": true,
+			},
+			currency:        "INR",
+			expectRecurring: true,
+		},
+		{
+			name: "non-INR recurring with token uses JSON API",
+			params: map[string]interface{}{
+				"amount":    10000,
+				"order_id":  "order_129837127313912",
+				"token":     "token_MT48CvBhIC98MQ",
+				"recurring": true,
+			},
+			currency:        "USD",
+			expectRecurring: false,
+		},
+		{
+			name: "INR recurring without token uses JSON API",
+			params: map[string]interface{}{
+				"amount":    10000,
+				"order_id":  "order_129837127313912",
+				"recurring": true,
+			},
+			currency:        "INR",
+			expectRecurring: false,
+		},
+		{
+			name: "INR with token but recurring false uses JSON API",
+			params: map[string]interface{}{
+				"amount":    10000,
+				"order_id":  "order_129837127313912",
+				"token":     "token_MT48CvBhIC98MQ",
+				"recurring": false,
+			},
+			currency:        "INR",
+			expectRecurring: false,
+		},
+		{
+			name: "INR with token and no recurring flag uses JSON API",
+			params: map[string]interface{}{
+				"amount":   10000,
+				"order_id": "order_129837127313912",
+				"token":    "token_MT48CvBhIC98MQ",
+			},
+			currency:        "INR",
+			expectRecurring: false,
+		},
+		{
+			name: "INR recurring with empty token uses JSON API",
+			params: map[string]interface{}{
+				"amount":    10000,
+				"order_id":  "order_129837127313912",
+				"token":     "",
+				"recurring": true,
+			},
+			currency:        "INR",
+			expectRecurring: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expectedPath := initiatePaymentPath
+			if tt.expectRecurring {
+				expectedPath = recurringPaymentPath
+			}
+
+			client, server := newMockRzpClient(func() (*http.Client, *httptest.Server) {
+				return mock.NewHTTPClient(mock.Endpoint{
+					Path:     expectedPath,
+					Method:   "POST",
+					Response: successResp,
+				})
+			})
+			defer server.Close()
+
+			payment, err := createPaymentWithParams(
+				client,
+				tt.params,
+				tt.currency,
+				"cust_RGCgP2osfPKFq2",
+			)
+			if err != nil {
+				t.Fatalf("createPaymentWithParams() error = %v", err)
+			}
+
+			if payment["razorpay_payment_id"] != "pay_test123" {
+				t.Fatalf("unexpected payment response: %v", payment)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Fixes inverted recurring-payment API routing in `createPaymentWithParams`. When `recurring=true`, a token is provided, and currency is INR, the tool now calls `CreateRecurringPayment` (`/v1/payments/create/recurring`) instead of incorrectly falling through to `CreatePaymentJson` (`/v1/payments/create/json`).

This aligns with Razorpay's recurring docs for UPI/card/NACH subsequent debits (e.g. single-block-multiple-debit mandates), where INR mandate charges use the dedicated recurring endpoint. Non-INR recurring requests continue to use the S2S JSON flow.

Also updates tool/README documentation and adds regression tests for API routing edge cases.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, code improvements only)
- [x] Documentation update
- [ ] Performance improvement

## Testing

- [x] Manual testing — verified via mock endpoint routing tests (wrong path returns 404)
- [x] Added unit tests
- [ ] Added integration tests (if applicable) — N/A
- [x] All tests pass locally — `go test ./... -count=1`

**New/updated tests:**
- `Test_InitiatePayment` — INR recurring mocks `create/recurring`; non-INR recurring mocks `create/json`
- `Test_createPaymentWithParams_recurringAPIRouting` — table-driven cases for INR/non-INR, missing/empty token, and `recurring=false`

## Checklist

- [x] I have followed the code style of this project
- [x] I have added comments to code where necessary, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary
- [x] I have verified that my changes do not introduce new warnings or errors
- [x] I have checked for and resolved any merge conflicts
- [x] I have considered the performance implications of my changes

## Additional Information

**Routing after fix:**

| `recurring` | `token` | `currency` | API |
|---|---|---|---|
| `true` | set | INR | `CreateRecurringPayment` |
| `true` | set | non-INR | `CreatePaymentJson` |
| otherwise | — | — | `CreatePaymentJson` |

**Note:** This corrects API fidelity for INR recurring flows. Callers that previously relied on the incorrect `create/json` path for INR recurring debits will now hit the proper recurring endpoint.