### PR TITLE
fix: simplify ResendOtp response handling

### DIFF
--- a/pkg/razorpay/payments.go
+++ b/pkg/razorpay/payments.go
@@ -921,24 +921,16 @@ func ResendOtp(
 			"response_data": otpResponse,
 		}
 
-		// Add next step instructions if OTP submit URL is available
+		// Next-step guidance is always returned; include submit URL when present.
+		response["next_step"] = "Use 'submit_otp' tool with the OTP code received " +
+			"from user to complete payment authentication."
+		response["next_tool"] = "submit_otp"
+		response["next_tool_params"] = map[string]interface{}{
+			"payment_id": paymentID,
+			"otp_string": "{OTP_CODE_FROM_USER}",
+		}
 		if otpSubmitURL != "" {
 			response["otp_submit_url"] = otpSubmitURL
-			response["next_step"] = "Use 'submit_otp' tool with the OTP code received " +
-				"from user to complete payment authentication."
-			response["next_tool"] = "submit_otp"
-			response["next_tool_params"] = map[string]interface{}{
-				"payment_id": paymentID,
-				"otp_string": "{OTP_CODE_FROM_USER}",
-			}
-		} else {
-			response["next_step"] = "Use 'submit_otp' tool with the OTP code received " +
-				"from user to complete payment authentication."
-			response["next_tool"] = "submit_otp"
-			response["next_tool_params"] = map[string]interface{}{
-				"payment_id": paymentID,
-				"otp_string": "{OTP_CODE_FROM_USER}",
-			}
 		}
 
 		result, err := mcpgo.NewToolResultJSON(response)


### PR DESCRIPTION
Removes duplicated `if/else` logic in `ResendOtp` where both branches set identical `next_step`, `next_tool`, and `next_tool_params` fields. The only difference was whether `otp_submit_url` was included.

**Change:** Set the common next-step fields once, then add `otp_submit_url` only when `extractOtpSubmitURL` returns a non-empty value. Behavior is unchanged — purely a readability refactor.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no functional changes, code improvements only)
- [ ] Documentation update
- [ ] Performance improvement

## Testing

- [x] Manual testing — verified via existing unit tests (both with and without `otp_submit_url`)
- [ ] Added unit tests — N/A (existing tests cover both paths)
- [ ] Added integration tests (if applicable) — N/A
- [x] All tests pass locally — `go test ./... -count=1`

**Existing tests verified:**
- `Test_ResendOtp/successful_OTP_resend` — includes `otp_submit_url`
- `Test_ResendOtp/OTP_resend_without_next_actions` — omits `otp_submit_url`, same `next_*` fields

## Checklist

- [x] I have followed the code style of this project
- [x] I have added comments to code where necessary, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary — N/A (no user-facing behavior change)
- [x] I have verified that my changes do not introduce new warnings or errors
- [x] I have checked for and resolved any merge conflicts
- [x] I have considered the performance implications of my changes

## Additional Information

**Before:** 18 lines with duplicated field assignments in `if`/`else` branches.

**After:** 10 lines — common fields set once, conditional `otp_submit_url` only.

No API or tool response shape changes for callers.