### PR TITLE
fix: correct upi_link parameter type

### DIFF
--- a/pkg/razorpay/payment_links.go
+++ b/pkg/razorpay/payment_links.go
@@ -259,8 +259,9 @@ func CreateUpiPaymentLink(
 			return result, err
 		}
 
-		// Add the required UPI payment link parameters
-		upiPlCreateReq["upi_link"] = "true"
+		// Required for UPI link creation; API expects boolean true (not a string).
+		// fetch_all_payment_links uses upi_link as an int query filter (0/1) instead.
+		upiPlCreateReq["upi_link"] = true
 
 		// Handle customer details
 		if len(customer) > 0 {
@@ -289,7 +290,8 @@ func CreateUpiPaymentLink(
 
 	return mcpgo.NewTool(
 		"payment_link_upi_create",
-		"Create a new UPI payment link in Razorpay with a specified amount and additional options.", // nolint:lll
+		"Create a new UPI payment link in Razorpay with a specified amount and "+
+			"additional options. Sets upi_link=true (boolean) in the API request.",
 		parameters,
 		handler,
 	)
@@ -517,9 +519,10 @@ func FetchAllPaymentLinks(
 		),
 		mcpgo.WithNumber(
 			"upi_link",
-			mcpgo.Description("Optional: Filter only upi links. "+
-				"Value should be 1 if you want only upi links, 0 for only standard links"+
-				"If not provided, all types of links will be returned"),
+			mcpgo.Description("Optional list filter only (not the create-body field). "+
+				"Use 1 for UPI links, 0 for standard links; omit to return all. "+
+				"Create UPI links via payment_link_upi_create, which sets upi_link "+
+				"to boolean true in the request body."),
 		),
 	}
 

--- a/pkg/razorpay/payment_links_test.go
+++ b/pkg/razorpay/payment_links_test.go
@@ -1,6 +1,8 @@
 package razorpay
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -326,6 +328,68 @@ func Test_CreateUpiPaymentLink(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			runToolTest(t, tc, CreateUpiPaymentLink, "UPI Payment Link")
 		})
+	}
+}
+
+func Test_CreateUpiPaymentLink_requestBody(t *testing.T) {
+	createPaymentLinkPath := fmt.Sprintf(
+		"/%s%s",
+		constants.VERSION_V1,
+		constants.PaymentLink_URL,
+	)
+
+	var capturedBody map[string]interface{}
+	successResp := map[string]interface{}{
+		"id":       "plink_UpiBodyTest",
+		"amount":   float64(50000),
+		"currency": "INR",
+		"status":   "created",
+		"upi_link": true,
+	}
+
+	mockClient, server := newMockRzpClient(func() (*http.Client, *httptest.Server) {
+		srv := httptest.NewServer(http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != createPaymentLinkPath || r.Method != http.MethodPost {
+					http.NotFound(w, r)
+					return
+				}
+
+				if err := json.NewDecoder(r.Body).Decode(&capturedBody); err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(successResp)
+			},
+		))
+		return srv.Client(), srv
+	})
+	defer server.Close()
+
+	obs := CreateTestObservability()
+	tool := CreateUpiPaymentLink(obs, mockClient)
+	request := createMCPRequest(map[string]interface{}{
+		"amount":   float64(50000),
+		"currency": "INR",
+	})
+
+	result, err := tool.GetHandler()(context.Background(), request)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("unexpected tool error: %v", result)
+	}
+
+	upiLink, ok := capturedBody["upi_link"].(bool)
+	if !ok {
+		t.Fatalf("expected upi_link bool in request body, got %T (%v)",
+			capturedBody["upi_link"], capturedBody["upi_link"])
+	}
+	if !upiLink {
+		t.Fatal("expected upi_link to be true")
 	}
 }
 


### PR DESCRIPTION
Fixes incorrect `upi_link` type in `CreateUpiPaymentLink`. The tool was sending `"true"` (string) in the POST body; Razorpay’s entity schema and razorpay-node SDK expect **boolean** `true`.

**Changes:**
- `upiPlCreateReq["upi_link"] = true` (boolean) instead of `"true"` (string)
- Clarified in comments and tool descriptions that **create** uses boolean `upi_link`, while **`fetch_all_payment_links`** uses int `0`/`1` as a list query filter (separate API surface, unchanged)
- Added `Test_CreateUpiPaymentLink_requestBody` to assert the outgoing request sends boolean `true`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no functional changes, code improvements only)
- [x] Documentation update
- [ ] Performance improvement

## Testing

- [x] Manual testing — verified via request-body unit test (boolean sent in JSON payload)
- [x] Added unit tests
- [ ] Added integration tests (if applicable) — N/A (no live test-mode credentials available)
- [x] All tests pass locally — `go test ./... -count=1`

**New test:**
- `Test_CreateUpiPaymentLink_requestBody` — captures POST body, asserts `upi_link` is `bool` `true`

## Checklist

- [x] I have followed the code style of this project
- [x] I have added comments to code where necessary, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary
- [x] I have verified that my changes do not introduce new warnings or errors
- [x] I have checked for and resolved any merge conflicts
- [x] I have considered the performance implications of my changes

## Additional Information

**Type mapping clarified:**

| API | `upi_link` type | Purpose |
|---|---|---|
| `payment_link_upi_create` (POST body) | **boolean** `true` | Mark link as UPI |
| `fetch_all_payment_links` (query filter) | **int** `0` or `1` | Filter list results |

**Reference:** [razorpay-node paymentLink.md](https://github.com/razorpay/razorpay-node/blob/master/documents/paymentLink.md) uses `"upi_link": true` (boolean) for UPI create. Response entities also return boolean `upi_link`.