### PR TITLE
fix: standardize token parameter validation

### DIFF
--- a/pkg/razorpay/tokens.go
+++ b/pkg/razorpay/tokens.go
@@ -46,21 +46,28 @@ func FetchSavedPaymentMethods(
 			return mcpgo.NewToolResultError(err.Error()), nil
 		}
 
-		validator := NewValidator(&r)
+		params := make(map[string]interface{})
 
-		customerIDValue, _ := extractValueGeneric[string](
-			&r, "customer_id", false)
-		contactValue, _ := extractValueGeneric[string](
-			&r, "contact", false)
+		validator := NewValidator(&r).
+			ValidateAndAddOptionalString(params, "customer_id").
+			ValidateAndAddOptionalString(params, "contact")
 
-		hasCustomerID := customerIDValue != nil && *customerIDValue != ""
-		hasContact := contactValue != nil && *contactValue != ""
+		hasCustomerID := false
+		hasContact := false
+		if v, ok := params["customer_id"].(string); ok && v != "" {
+			hasCustomerID = true
+		}
+		if v, ok := params["contact"].(string); ok && v != "" {
+			hasContact = true
+		}
 
-		if !hasCustomerID && !hasContact {
+		// At least one non-empty identifier is required when params are valid.
+		if !hasCustomerID && !hasContact && !validator.HasErrors() {
 			validator = validator.addError(
 				fmt.Errorf(
 					"either customer_id or contact must be provided"))
 		}
+
 		if result, err := validator.HandleErrorsIfAny(); result != nil {
 			return result, err
 		}
@@ -69,7 +76,7 @@ func FetchSavedPaymentMethods(
 		var customer map[string]interface{}
 
 		if hasCustomerID {
-			customerID = *customerIDValue
+			customerID = params["customer_id"].(string)
 
 			url := fmt.Sprintf("/%s%s/%s",
 				constants.VERSION_V1,
@@ -78,13 +85,10 @@ func FetchSavedPaymentMethods(
 			customer, err = client.Request.Get(url, nil, nil)
 			if err != nil {
 				return mcpgo.NewToolResultError(
-					fmt.Sprintf(
-						"Failed to fetch customer %s: %v",
-						customerID, err,
-					)), nil
+					formatErrorMessage("fetching customer failed", err)), nil
 			}
 		} else {
-			contact := *contactValue
+			contact := params["contact"].(string)
 			customerData := map[string]interface{}{
 				"contact":       contact,
 				"fail_existing": "0",
@@ -93,10 +97,8 @@ func FetchSavedPaymentMethods(
 			customer, err = client.Customer.Create(customerData, nil)
 			if err != nil {
 				return mcpgo.NewToolResultError(
-					fmt.Sprintf(
-						"Failed to create/fetch customer with contact %s: %v",
-						contact, err,
-					)), nil
+					formatErrorMessage(
+						"creating or fetching customer failed", err)), nil
 			}
 
 			id, ok := customer["id"].(string)
@@ -113,11 +115,8 @@ func FetchSavedPaymentMethods(
 		tokensResponse, err := client.Request.Get(url, nil, nil)
 		if err != nil {
 			return mcpgo.NewToolResultError(
-				fmt.Sprintf(
-					"Failed to fetch saved payment methods for customer %s: %v",
-					customerID,
-					err,
-				)), nil
+				formatErrorMessage(
+					"fetching saved payment methods failed", err)), nil
 		}
 
 		result := map[string]interface{}{
@@ -178,33 +177,18 @@ func RevokeToken(
 			return mcpgo.NewToolResultError(err.Error()), nil
 		}
 
-		validator := NewValidator(&r)
+		params := make(map[string]interface{})
 
-		// Validate required customer_id parameter
-		customerIDValue, err := extractValueGeneric[string](&r, "customer_id", true)
-		if err != nil {
-			validator = validator.addError(err)
-		} else if customerIDValue == nil || *customerIDValue == "" {
-			validator = validator.addError(
-				fmt.Errorf("missing required parameter: customer_id"))
-		}
+		validator := NewValidator(&r).
+			ValidateAndAddRequiredString(params, "customer_id").
+			ValidateAndAddRequiredString(params, "token_id")
+
 		if result, err := validator.HandleErrorsIfAny(); result != nil {
 			return result, err
 		}
-		customerID := *customerIDValue
 
-		// Validate required token_id parameter
-		tokenIDValue, err := extractValueGeneric[string](&r, "token_id", true)
-		if err != nil {
-			validator = validator.addError(err)
-		} else if tokenIDValue == nil || *tokenIDValue == "" {
-			validator = validator.addError(
-				fmt.Errorf("missing required parameter: token_id"))
-		}
-		if result, err := validator.HandleErrorsIfAny(); result != nil {
-			return result, err
-		}
-		tokenID := *tokenIDValue
+		customerID := params["customer_id"].(string)
+		tokenID := params["token_id"].(string)
 
 		url := fmt.Sprintf(
 			"/%s%s/%s/tokens/%s/cancel",
@@ -217,12 +201,7 @@ func RevokeToken(
 
 		if err != nil {
 			return mcpgo.NewToolResultError(
-				fmt.Sprintf(
-					"Failed to revoke token %s for customer %s: %v",
-					tokenID,
-					customerID,
-					err,
-				)), nil
+				formatErrorMessage("revoking token failed", err)), nil
 		}
 
 		return mcpgo.NewToolResultJSON(response)

--- a/pkg/razorpay/tokens_test.go
+++ b/pkg/razorpay/tokens_test.go
@@ -234,8 +234,8 @@ func Test_FetchSavedPaymentMethods(t *testing.T) {
 				)
 			},
 			ExpectError: true,
-			ExpectedErrMsg: "Failed to create/fetch customer with " +
-				"contact invalid_contact: Contact number is invalid",
+			ExpectedErrMsg: "creating or fetching customer failed: " +
+				"Contact number is invalid",
 		},
 		{
 			Name: "tokens API failure after successful customer creation",
@@ -258,8 +258,8 @@ func Test_FetchSavedPaymentMethods(t *testing.T) {
 				)
 			},
 			ExpectError: true,
-			ExpectedErrMsg: "Failed to fetch saved payment methods for " +
-				"customer cust_1Aa00000000003: Customer not found",
+			ExpectedErrMsg: "fetching saved payment methods failed: " +
+				"Customer not found",
 		},
 		{
 			Name: "invalid customer response - missing customer ID",
@@ -379,8 +379,7 @@ func Test_FetchSavedPaymentMethods(t *testing.T) {
 				)
 			},
 			ExpectError: true,
-			ExpectedErrMsg: "Failed to fetch customer cust_nonexistent: " +
-				"Customer not found",
+			ExpectedErrMsg: "fetching customer failed: Customer not found",
 		},
 		{
 			Name: "tokens API failure after successful customer_id fetch", //nolint:lll
@@ -404,8 +403,8 @@ func Test_FetchSavedPaymentMethods(t *testing.T) {
 				)
 			},
 			ExpectError: true,
-			ExpectedErrMsg: "Failed to fetch saved payment methods for " +
-				"customer cust_1Aa00000000003: Customer not found",
+			ExpectedErrMsg: "fetching saved payment methods failed: " +
+				"Customer not found",
 		},
 		// --- validation error tests ---
 		{
@@ -450,6 +449,24 @@ func Test_FetchSavedPaymentMethods(t *testing.T) {
 			MockHttpClient: nil,
 			ExpectError:    true,
 			ExpectedErrMsg: "either customer_id or contact must be provided",
+		},
+		{
+			Name: "invalid customer_id parameter type",
+			Request: map[string]interface{}{
+				"customer_id": 123,
+			},
+			MockHttpClient: nil,
+			ExpectError:    true,
+			ExpectedErrMsg: "invalid parameter type: customer_id",
+		},
+		{
+			Name: "invalid contact parameter type",
+			Request: map[string]interface{}{
+				"contact": 9876543210,
+			},
+			MockHttpClient: nil,
+			ExpectError:    true,
+			ExpectedErrMsg: "invalid parameter type: contact",
 		},
 	}
 
@@ -608,8 +625,7 @@ func Test_RevokeToken(t *testing.T) {
 				)
 			},
 			ExpectError: true,
-			ExpectedErrMsg: "Failed to revoke token token_nonexistent for " +
-				"customer cust_1Aa00000000003: Token not found",
+			ExpectedErrMsg: "revoking token failed: Token not found",
 		},
 		{
 			Name: "customer not found error",
@@ -631,8 +647,7 @@ func Test_RevokeToken(t *testing.T) {
 				)
 			},
 			ExpectError: true,
-			ExpectedErrMsg: "Failed to revoke token token_ABCDEFGH for " +
-				"customer cust_nonexistent: Customer not found",
+			ExpectedErrMsg: "revoking token failed: Customer not found",
 		},
 		{
 			Name: "missing customer_id parameter",
@@ -647,26 +662,6 @@ func Test_RevokeToken(t *testing.T) {
 			Name: "missing token_id parameter",
 			Request: map[string]interface{}{
 				"customer_id": "cust_1Aa00000000003",
-			},
-			MockHttpClient: nil, // No HTTP client needed for validation error
-			ExpectError:    true,
-			ExpectedErrMsg: "missing required parameter: token_id",
-		},
-		{
-			Name: "empty customer_id parameter",
-			Request: map[string]interface{}{
-				"customer_id": "",
-				"token_id":    "token_ABCDEFGH",
-			},
-			MockHttpClient: nil, // No HTTP client needed for validation error
-			ExpectError:    true,
-			ExpectedErrMsg: "missing required parameter: customer_id",
-		},
-		{
-			Name: "empty token_id parameter",
-			Request: map[string]interface{}{
-				"customer_id": "cust_1Aa00000000003",
-				"token_id":    "",
 			},
 			MockHttpClient: nil, // No HTTP client needed for validation error
 			ExpectError:    true,
@@ -699,7 +694,21 @@ func Test_RevokeToken(t *testing.T) {
 			},
 			MockHttpClient: nil, // No HTTP client needed for validation error
 			ExpectError:    true,
-			ExpectedErrMsg: "missing required parameter: customer_id",
+			ExpectedErrMsg: "Validation errors:\n- " +
+				"missing required parameter: customer_id\n- " +
+				"missing required parameter: token_id",
+		},
+		{
+			Name: "multiple validation errors",
+			Request: map[string]interface{}{
+				"customer_id": 123,
+				"token_id":    true,
+			},
+			MockHttpClient: nil,
+			ExpectError:    true,
+			ExpectedErrMsg: "Validation errors:\n- " +
+				"invalid parameter type: customer_id\n- " +
+				"invalid parameter type: token_id",
 		},
 	}
 


### PR DESCRIPTION
Refactors `FetchSavedPaymentMethods` and `RevokeToken` in `pkg/razorpay/tokens.go` to use the standard `NewValidator` fluent pattern instead of hand-rolled `extractValueGeneric` calls.

**`fetch_tokens` (`FetchSavedPaymentMethods`)**
- Validates `customer_id` and `contact` via `ValidateAndAddOptionalString`, so type errors (e.g. `customer_id: 123`) return `invalid parameter type: customer_id` instead of the misleading either-or message
- Keeps the either-or rule: at least one non-empty identifier is required when params are otherwise valid
- Aligns API error messages with `formatErrorMessage` (`fetching customer failed`, `creating or fetching customer failed`, `fetching saved payment methods failed`)

**`revoke_token` (`RevokeToken`)**
- Validates both required params in one chain with a single `HandleErrorsIfAny()` call, so missing both params returns all validation errors at once
- Removes redundant manual empty-string checks (consistent with other tools like `FetchPayment`)
- Aligns API error messages with `formatErrorMessage` (`revoking token failed`)

Tests in `pkg/razorpay/tokens_test.go` were updated for the new validation and error-message behavior, including invalid-type cases and combined validation errors.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no functional changes, code improvements only)
- [ ] Documentation update
- [ ] Performance improvement

## Testing

- [x] Manual testing
- [x] Added unit tests
- [ ] Added integration tests (if applicable)
- [x] All tests pass locally

**Commands run:**
```bash
go test ./pkg/razorpay/... -v -run "Test_FetchSavedPaymentMethods|Test_RevokeToken"
go test ./... -count=1
```

## Checklist

- [x] I have followed the code style of this project
- [x] I have added comments to code where necessary, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary
- [x] I have verified that my changes do not introduce new warnings or errors
- [x] I have checked for and resolved any merge conflicts
- [x] I have considered the performance implications of my changes

## Additional Information

**Files changed:** `pkg/razorpay/tokens.go`, `pkg/razorpay/tokens_test.go`

**Behavior note:** Empty-string values for required `RevokeToken` params are no longer rejected at validation time (matches the standard validator used elsewhere). Null/missing params still fail validation; invalid types return proper type errors.

**Docs:** No README update — tool names, parameters, and public descriptions are unchanged; only internal validation and error formatting were updated.