### PR TITLE
feat(refunds): support idempotency key on create_refund

### DIFF
--- a/pkg/razorpay/refunds.go
+++ b/pkg/razorpay/refunds.go
@@ -9,6 +9,24 @@ import (
 	"github.com/razorpay/razorpay-mcp-server/pkg/observability"
 )
 
+// refundIdempotencyHeaderName is the header Razorpay uses to deduplicate
+// refund requests. See
+// https://razorpay.com/docs/api/refunds/normal-refunds-idempotent/
+const refundIdempotencyHeaderName = "X-Refund-Idempotency"
+
+// refundIdempotencyHeaders builds the extra headers for a refund request.
+// Returns nil when no key was supplied, preserving the previous behaviour.
+func refundIdempotencyHeaders(
+	params map[string]interface{},
+) map[string]string {
+	key, ok := params["idempotency_key"].(string)
+	if !ok || key == "" {
+		return nil
+	}
+
+	return map[string]string{refundIdempotencyHeaderName: key}
+}
+
 // CreateRefund returns a tool that creates a normal refund for a payment
 func CreateRefund(
 	obs *observability.Observability,
@@ -42,7 +60,18 @@ func CreateRefund(
 		mcpgo.WithString(
 			"receipt",
 			mcpgo.Description("A unique identifier provided by you for "+
-				"your internal reference."),
+				"your internal reference. Also acts as an idempotency key: "+
+				"reusing a receipt on the same payment is rejected rather "+
+				"than creating a second refund."),
+		),
+		mcpgo.WithString(
+			"idempotency_key",
+			mcpgo.Description("A unique key that makes this refund safe to "+
+				"retry, sent as the X-Refund-Idempotency header. If a request "+
+				"is retried with the same key, Razorpay returns the original "+
+				"refund instead of creating a second one. Must be at least 10 "+
+				"characters. Strongly recommended: without it, retrying after "+
+				"a network timeout can refund the customer twice."),
 		),
 	}
 
@@ -58,21 +87,25 @@ func CreateRefund(
 
 		payload := make(map[string]interface{})
 		data := make(map[string]interface{})
+		headerParams := make(map[string]interface{})
 
 		validator := NewValidator(&r).
 			ValidateAndAddRequiredString(payload, "payment_id").
 			ValidateAndAddRequiredFloat(payload, "amount").
 			ValidateAndAddOptionalString(data, "speed").
 			ValidateAndAddOptionalString(data, "receipt").
-			ValidateAndAddOptionalMap(data, "notes")
+			ValidateAndAddOptionalMap(data, "notes").
+			ValidateAndAddOptionalString(headerParams, "idempotency_key")
 
 		if result, err := validator.HandleErrorsIfAny(); result != nil {
 			return result, err
 		}
 
+		extraHeaders := refundIdempotencyHeaders(headerParams)
+
 		refund, err := client.Payment.Refund(
 			payload["payment_id"].(string),
-			int(payload["amount"].(float64)), data, nil)
+			int(payload["amount"].(float64)), data, extraHeaders)
 		if err != nil {
 			return mcpgo.NewToolResultError(
 				formatErrorMessage("creating refund failed", err)), nil

--- a/pkg/razorpay/refunds_test.go
+++ b/pkg/razorpay/refunds_test.go
@@ -1,11 +1,16 @@
 package razorpay
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
+	rzpsdk "github.com/razorpay/razorpay-go"
 	"github.com/razorpay/razorpay-go/constants"
 
 	"github.com/razorpay/razorpay-mcp-server/pkg/razorpay/mock"
@@ -727,6 +732,85 @@ func Test_FetchAllRefunds(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
 			runToolTest(t, tc, FetchAllRefunds, "Refund")
+		})
+	}
+}
+
+func Test_CreateRefund_IdempotencyHeader(t *testing.T) {
+	refundResp := map[string]interface{}{
+		"id":         "rfnd_FP8QHiV938haTz",
+		"entity":     "refund",
+		"amount":     float64(500100),
+		"payment_id": "pay_29QQoUBi66xm2f",
+		"status":     "processed",
+	}
+
+	tests := []struct {
+		name       string
+		request    map[string]interface{}
+		wantHeader string
+	}{
+		{
+			name: "sends X-Refund-Idempotency when key is supplied",
+			request: map[string]interface{}{
+				"payment_id":      "pay_29QQoUBi66xm2f",
+				"amount":          float64(500100),
+				"idempotency_key": "refund-order-42-attempt",
+			},
+			wantHeader: "refund-order-42-attempt",
+		},
+		{
+			name: "omits the header when no key is supplied",
+			request: map[string]interface{}{
+				"payment_id": "pay_29QQoUBi66xm2f",
+				"amount":     float64(500100),
+			},
+			wantHeader: "",
+		},
+		{
+			name: "omits the header when the key is empty",
+			request: map[string]interface{}{
+				"payment_id":      "pay_29QQoUBi66xm2f",
+				"amount":          float64(500100),
+				"idempotency_key": "",
+			},
+			wantHeader: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotHeader string
+			var gotBody map[string]interface{}
+
+			server := httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, r *http.Request) {
+					gotHeader = r.Header.Get("X-Refund-Idempotency")
+					_ = json.NewDecoder(r.Body).Decode(&gotBody)
+
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(refundResp)
+				}))
+			defer server.Close()
+
+			client := rzpsdk.NewClient("sample_key", "sample_secret")
+			req := client.Order.Request
+			req.BaseURL = server.URL
+			req.HTTPClient = server.Client()
+
+			tool := CreateRefund(CreateTestObservability(), client)
+			result, err := tool.GetHandler()(
+				context.Background(), createMCPRequest(tc.request))
+
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, tc.wantHeader, gotHeader)
+
+			// The key travels as a header and must not leak into the body.
+			_, inBody := gotBody["idempotency_key"]
+			assert.False(t, inBody,
+				"idempotency_key must not be sent in the request body")
 		})
 	}
 }


### PR DESCRIPTION
## Problem

The Refunds API supports idempotent requests via the `X-Refund-Idempotency` header ([docs](https://razorpay.com/docs/api/refunds/normal-refunds-idempotent/)), but `create_refund` cannot use it:

https://github.com/razorpay/razorpay-mcp-server/blob/main/pkg/razorpay/refunds.go#L73-L75

```go
refund, err := client.Payment.Refund(
    payload["payment_id"].(string),
    int(payload["amount"].(float64)), data, nil)
```

That trailing `nil` is `extraHeaders`, so the header is never sent — and there is no tool parameter through which a caller could supply one. The tool schema an agent sees is:

```
create_refund parameters: ['amount', 'notes', 'payment_id', 'receipt', 'speed']
```

`receipt` does act as an idempotency key server-side, but it is described as *"A unique identifier provided by you for your internal reference"* — nothing indicates it prevents duplicate refunds, so a model has no reason to set it.

### Why this matters for agent callers

MCP callers are frequently autonomous. When a refund commits server-side but the response is lost in transit, the agent observes a failure and the natural next action is a retry. Without an idempotency key, that retry refunds the customer a second time.

Verified against test mode on the current `main` — three `create_refund` calls, no key available to pass, produced three distinct refunds:

```
refund #1 -> rfnd_TQU9nsnDXG4WaB
refund #2 -> rfnd_TQU9q2NaytcbFg
refund #3 -> rfnd_TQU9sXvlQREtyv
total refunds on payment: 3   |   amount_refunded: 300
```

## Change

- adds an optional `idempotency_key` tool parameter, sent as `X-Refund-Idempotency`
- extends the `receipt` description to mention it also acts as an idempotency key
- extracts `refundIdempotencyHeaders` so the header map is built in one place

Backward compatible: when `idempotency_key` is omitted the helper returns `nil` and the call is byte-for-byte what it is today.

## Verification

Built this branch and drove it over MCP stdio against test mode. The parameter now appears in the schema:

```
create_refund parameters: ['amount', 'idempotency_key', 'notes', 'payment_id', 'receipt', 'speed']
```

Two `create_refund` calls with the same `idempotency_key`, through the MCP tool surface, against the live test API:

```
call 1 -> refund id rfnd_TQWWggEvedFT8W
call 2 -> refund id rfnd_TQWWggEvedFT8W
refunds on payment: 1
```

The second call returns the original refund instead of creating a second one.

## Tests

Adds `Test_CreateRefund_IdempotencyHeader`, covering that the header is sent when a key is supplied, omitted when absent, omitted when empty, and that the key never leaks into the request body. It uses `httptest` directly to capture request headers, since the shared mock helper matches on path and method only.

`go test ./...` and `go vet ./pkg/...` pass.
