### PR TITLE
security: add SafeDep PMG to all CI workflows

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -10,6 +10,13 @@ jobs:
   assign:
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Package Manager Guard
+        uses: safedep/pmg@v1
+        with:
+          server-mode: true
+          api-key: ${{ secrets.SAFEDEP_API_KEY }}
+          tenant-id: ${{ secrets.SAFEDEP_TENANT_ID }}
+
       - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           # Please add your name to assignees
@@ -20,3 +27,7 @@ jobs:
               repo: context.repo.repo,
               assignees: ['RZP7464','jating06','paraskathuria-dev','nikhil-rzp', 'ankitchoudhary2209']
             })
+
+      - name: Enforce PMG policy
+        if: always()
+        run: pmg proxy stop --fail-on-violation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,14 @@ jobs:
         with:
           go-version-file: "go.mod"
 
+      - name: Set up Package Manager Guard
+        if: runner.os == 'Linux'
+        uses: safedep/pmg@v1
+        with:
+          server-mode: true
+          api-key: ${{ secrets.SAFEDEP_API_KEY }}
+          tenant-id: ${{ secrets.SAFEDEP_TENANT_ID }}
+
       - name: Download dependencies
         run: go mod download
 
@@ -30,3 +38,7 @@ jobs:
 
       - name: Build
         run: go build -v ./cmd/razorpay-mcp-server
+
+      - name: Enforce PMG policy
+        if: always() && runner.os == 'Linux'
+        run: pmg proxy stop --fail-on-violation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     branches:
       - main
+
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run tests and publish test coverage
@@ -19,6 +23,13 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: '1.23'
+
+      - name: Set up Package Manager Guard
+        uses: safedep/pmg@v1
+        with:
+          server-mode: true
+          api-key: ${{ secrets.SAFEDEP_API_KEY }}
+          tenant-id: ${{ secrets.SAFEDEP_TENANT_ID }}
 
       - name: Run coverage
         run: |
@@ -32,3 +43,7 @@ jobs:
            name: codecov-umbrella
            fail_ci_if_error: true
            verbose: true
+
+      - name: Enforce PMG policy
+        if: always()
+        run: pmg proxy stop --fail-on-violation

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -24,6 +27,13 @@ jobs:
         with:
           username: ${{ secrets.PUBLIC_DOCKER_USERNAME }}
           password: ${{ secrets.PUBLIC_DOCKER_PASSWORD }}
+
+      - name: Set up Package Manager Guard
+        uses: safedep/pmg@v1
+        with:
+          server-mode: true
+          api-key: ${{ secrets.SAFEDEP_API_KEY }}
+          tenant-id: ${{ secrets.SAFEDEP_TENANT_ID }}
 
       - name: Get Build Info
         id: build_info
@@ -58,3 +68,7 @@ jobs:
             VERSION=${{ github.ref_name }}
             COMMIT=${{ steps.build_info.outputs.trigger_sha }}
             BUILD_DATE=${{ steps.build_info.outputs.build_date }}
+
+      - name: Enforce PMG policy
+        if: always()
+        run: pmg proxy stop --fail-on-violation

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,13 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
+      - name: Set up Package Manager Guard
+        uses: safedep/pmg@v1
+        with:
+          server-mode: true
+          api-key: ${{ secrets.SAFEDEP_API_KEY }}
+          tenant-id: ${{ secrets.SAFEDEP_TENANT_ID }}
+
       - name: Verify dependencies
         run: |
           go mod verify
@@ -48,3 +55,7 @@ jobs:
           bin/golangci-lint run --out-format=colored-line-number --timeout=3m || STATUS=$?
 
           exit $STATUS
+
+      - name: Enforce PMG policy
+        if: always()
+        run: pmg proxy stop --fail-on-violation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,13 @@ jobs:
         with:
           go-version-file: "go.mod"
 
+      - name: Set up Package Manager Guard
+        uses: safedep/pmg@v1
+        with:
+          server-mode: true
+          api-key: ${{ secrets.SAFEDEP_API_KEY }}
+          tenant-id: ${{ secrets.SAFEDEP_TENANT_ID }}
+
       - name: Download dependencies
         run: go mod download
 
@@ -43,3 +50,7 @@ jobs:
             dist/*.tar.gz
             dist/*.zip
             dist/*.txt
+
+      - name: Enforce PMG policy
+        if: always()
+        run: pmg proxy stop --fail-on-violation


### PR DESCRIPTION
Wires SafeDep Package Manager Guard into every job across all six workflows, following the pattern in [the SafeDep GitHub Actions docs](https://docs.safedep.io/package-security/pmg/github-actions): start the action in `server-mode` after toolchain setup, let it proxy dependency resolution, and end the job with `pmg proxy stop --fail-on-violation`.

## Coverage

| Workflow | Job | Notes |
|---|---|---|
| `build.yml` | `build` | Matrix ×3 OS — gated to the Linux leg |
| `ci.yml` | `test` | Codecov upload stays ahead of the enforce step |
| `lint.yml` | `lint` | |
| `release.yml` | `release` | |
| `docker-publish.yml` | `build` | Present, but does not reach into BuildKit — see below |
| `assign.yml` | `assign` | Installs nothing; included for uniformity |

## Please read before approving: this screens zero packages today

This repo is pure Go. PMG supports npm, pnpm, yarn, bun, npx, pnpx, pip, uv and poetry — **not Go modules**. There is no `package.json`, no `requirements.txt`, and no npm/pip invocation anywhere in the workflows, the `Makefile` or the `Dockerfile`. Every dependency comes from `go mod download` via `GOPROXY`.

So this is inert scaffolding that becomes load-bearing the day a JS or Python component lands. It is included anyway for consistency with the org-wide rollout, at the cost of one extra action invocation per job. Flagging it plainly so nobody reads a green check here as supply-chain coverage that does not exist. For the Go side, that assurance comes from `go mod verify` (already in `lint.yml`), GOSUMDB, and would be better served by `govulncheck` or Dependabot.

## Placement rules applied

- Setup step goes **after** `setup-go`, so the toolchain download is not routed through the proxy.
- Enforce step is **last** in every job. `pmg proxy stop` leaves `HTTP_PROXY` set, so anything after it points at a dead proxy — hence Codecov ordering in `ci.yml`.
- `if: always()` on enforce, so violations surface even when an earlier step failed.

## Two jobs that needed special handling

**`build.yml`** runs a three-OS matrix but the PMG action is Linux-only. Both steps are gated on `runner.os == 'Linux'`; the windows and macos legs run unguarded rather than failing outright.

**`assign.yml`** intentionally keeps **no `permissions:` block**. The `contents: read` from the upstream docs snippet would strip the token scope `addAssignees` needs and break the job. It is also the only place the proxy sits in front of a GitHub API call — safe, because `pmg proxy env` exports `NODE_EXTRA_CA_CERTS` alongside `HTTPS_PROXY`, so `@actions/http-client` trusts the proxy CA and `api.github.com` passes through as a non-registry host.

## Known gap

`docker-publish.yml` has the step correctly ordered, but BuildKit does not inherit the runner's proxy environment, so `go mod download` inside the Dockerfile is not intercepted. Left as-is since there is nothing to screen in that build today; it needs build-args plumbing if the image ever installs npm or pip packages.

## ⚠️ Secrets — needs confirmation before merge

`SAFEDEP_API_KEY` and `SAFEDEP_TENANT_ID` are **all-or-nothing**:

- Both absent → PMG runs local-only, CI passes.
- Both present → cloud sync on, CI passes.
- **Exactly one present → the action fails with `api-key and tenant-id must be set together`, taking down all six jobs on every push and PR.**

Neither is configured at repo level, so they are presumably inherited from org secrets the same way `PUBLIC_DOCKER_USERNAME` / `PUBLIC_DOCKER_PASSWORD` already are. I could not verify that — reading org secrets needs admin. **Someone with org admin should confirm both names exist (or neither) before this merges:**

```
gh api /orgs/razorpay/actions/secrets --jq '.secrets[].name' | grep SAFEDEP
```

Two lines or zero is fine. One line is the problem.

## Verification

- All six workflows parse as valid YAML.
- Enforce step confirmed to be the final step in all six jobs.
- Diff is purely additive — no existing lines altered (the `-`/`+` pairs are pre-existing trailing whitespace, unchanged under `--ignore-all-space`).
- `go build`, `go vet`, and `go test ./...` all pass (9/9 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)