### PR TITLE
fix: append actionable guidance when initiate_payment hits an unrouted-style error

### DIFF
--- a/pkg/razorpay/payments.go
+++ b/pkg/razorpay/payments.go
@@ -706,6 +706,39 @@ func createPaymentWithParams(
 	return payment, err
 }
 
+// looksLikeUnroutedEndpointError detects a generic web-server/gateway "not
+// found" response body (e.g. "The requested URL was not found on the
+// server.") as opposed to Razorpay's normal structured validation/decline
+// error messages (which read like "The api key/secret provided is invalid"
+// or a specific field complaint). In practice this shape has been observed
+// on the create/json and create/recurring payment-creation endpoints when
+// the calling account does not have Server-to-Server (S2S) JSON payment API
+// access enabled, and the raw text alone gives no indication of that -- it
+// reads exactly like a client bug even when it isn't one.
+func looksLikeUnroutedEndpointError(msg string) bool {
+	lower := strings.ToLower(msg)
+	return strings.Contains(lower, "requested url") &&
+		strings.Contains(lower, "not found")
+}
+
+// wrapPaymentCreationError appends actionable guidance to a payment-creation
+// error when its shape suggests an unrouted/unavailable endpoint rather than
+// a normal Razorpay validation error, so a caller isn't left debugging what
+// looks like a code bug when it's more likely an account configuration gap.
+func wrapPaymentCreationError(err error) string {
+	msg := fmt.Sprintf("initiating payment failed: %s", err.Error())
+	if looksLikeUnroutedEndpointError(err.Error()) {
+		msg += ". This looks like a generic 'not found' response rather than " +
+			"a normal Razorpay validation error, which has been seen when the " +
+			"account does not have Server-to-Server (S2S) JSON payment API " +
+			"access enabled. Confirm S2S/create-payment access is enabled for " +
+			"this key (contact Razorpay support if unsure), or see " +
+			"https://razorpay.com/docs/payment-gateway/s2s-integration/ for " +
+			"prerequisites."
+	}
+	return msg
+}
+
 // InitiatePayment returns a tool that initiates a payment using order_id
 // and token
 // This implements the S2S JSON v1 flow for creating payments
@@ -836,8 +869,7 @@ func InitiatePayment(
 		// Create payment
 		payment, err := createPaymentWithParams(client, params, currency, customerID)
 		if err != nil {
-			return mcpgo.NewToolResultError(
-				fmt.Sprintf("initiating payment failed: %s", err.Error())), nil
+			return mcpgo.NewToolResultError(wrapPaymentCreationError(err)), nil
 		}
 
 		// Process payment result

--- a/pkg/razorpay/payments_test.go
+++ b/pkg/razorpay/payments_test.go
@@ -664,6 +664,17 @@ func Test_InitiatePayment(t *testing.T) {
 		},
 	}
 
+	// Modeled on a real, live-reproduced failure: the create/json payment
+	// endpoint returning a generic web-server "not found" style description
+	// instead of a normal Razorpay validation error -- observed when the
+	// calling account lacked Server-to-Server (S2S) JSON payment API access.
+	unroutedEndpointErrorResp := map[string]interface{}{
+		"error": map[string]interface{}{
+			"code":        "BAD_REQUEST_ERROR",
+			"description": "The requested URL was not found on the server.",
+		},
+	}
+
 	tests := []RazorpayToolTestCase{
 		{
 			Name: "successful payment initiation without next actions",
@@ -793,6 +804,30 @@ func Test_InitiatePayment(t *testing.T) {
 			},
 			ExpectError:    true,
 			ExpectedErrMsg: "initiating payment failed:",
+		},
+		{
+			Name: "payment initiation with unrouted-endpoint-style API error " +
+				"gets actionable S2S guidance appended",
+			Request: map[string]interface{}{
+				"amount":   10000,
+				"token":    "token_MT48CvBhIC98MQ",
+				"order_id": "order_129837127313912",
+			},
+			MockHttpClient: func() (*http.Client, *httptest.Server) {
+				return mock.NewHTTPClient(
+					mock.Endpoint{
+						Path:     initiatePaymentPath,
+						Method:   "POST",
+						Response: unroutedEndpointErrorResp,
+					},
+				)
+			},
+			ExpectError: true,
+			ExpectedErrMsg: "initiating payment failed: The requested URL was " +
+				"not found on the server.. This looks like a generic 'not " +
+				"found' response rather than a normal Razorpay validation " +
+				"error, which has been seen when the account does not have " +
+				"Server-to-Server (S2S) JSON payment API access enabled.",
 		},
 		{
 			Name: "missing required amount parameter",
@@ -4328,5 +4363,75 @@ func TestPayments100PercentCoverage_ContextErrors4(t *testing.T) {
 			ExpectedErrMsg: "failed",
 		}
 		runToolTest(t, testCase, FetchAllPayments, "Collection")
+	})
+}
+
+func Test_looksLikeUnroutedEndpointError(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+		want bool
+	}{
+		{
+			name: "the exact real-world message this was written for",
+			msg:  "The requested URL was not found on the server.",
+			want: true,
+		},
+		{
+			name: "case-insensitive match",
+			msg:  "THE REQUESTED URL WAS NOT FOUND ON THE SERVER.",
+			want: true,
+		},
+		{
+			name: "normal Razorpay validation error is not flagged",
+			msg:  "Invalid token",
+			want: false,
+		},
+		{
+			name: "normal Razorpay validation error mentioning 'found' alone " +
+				"is not flagged",
+			msg:  "No customer found for the given contact",
+			want: false,
+		},
+		{
+			name: "empty message",
+			msg:  "",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := looksLikeUnroutedEndpointError(tt.msg)
+			if got != tt.want {
+				t.Errorf("looksLikeUnroutedEndpointError(%q) = %v, want %v",
+					tt.msg, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_wrapPaymentCreationError(t *testing.T) {
+	t.Run("unrouted error gets guidance appended", func(t *testing.T) {
+		got := wrapPaymentCreationError(
+			fmt.Errorf("The requested URL was not found on the server."))
+		if !strings.Contains(got, "initiating payment failed: "+
+			"The requested URL was not found on the server.") {
+			t.Errorf("wrapPaymentCreationError did not preserve the "+
+				"original message, got: %q", got)
+		}
+		if !strings.Contains(got, "Server-to-Server (S2S)") {
+			t.Errorf("wrapPaymentCreationError did not append S2S guidance, "+
+				"got: %q", got)
+		}
+	})
+
+	t.Run("normal validation error is not decorated", func(t *testing.T) {
+		got := wrapPaymentCreationError(fmt.Errorf("Invalid token"))
+		want := "initiating payment failed: Invalid token"
+		if got != want {
+			t.Errorf("wrapPaymentCreationError(%q) = %q, want %q",
+				"Invalid token", got, want)
+		}
 	})
 }


### PR DESCRIPTION
## Description

`initiate_payment` can fail with a generic web-server "not found" style error
description (e.g. `"The requested URL was not found on the server."`) instead of a
normal Razorpay validation error. That raw text reads exactly like a client-side bug
-- it took real digging through `razorpay-go`'s request/error-handling code to
conclude it probably isn't one (see #131 for the full reproduction and analysis).

This PR does **not** change the underlying request/routing logic (I can't confirm
what the actual fix on Razorpay's side should be -- an account-level S2S feature gate
vs. something in the hosted deployment's routing are both plausible, per #131). It
detects this specific error shape and appends actionable guidance instead of passing
the confusing raw text through unexplained, so the next person who hits this doesn't
have to redo the same investigation from scratch.

## Related Issues

Related to #131 (does not resolve the underlying cause, which is unconfirmed -- see
the issue for why).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, code improvements only)
- [ ] Documentation update
- [ ] Performance improvement

## Testing

- [x] Manual testing -- reproduced live against the hosted Remote MCP Server
  (`https://mcp.razorpay.com/mcp`) with a real test-mode key; see #131 for the
  reproduction steps and real order IDs.
- [x] Added unit tests
- [ ] Added integration tests (if applicable) -- N/A, no network access from this
  environment's test suite
- [x] All tests pass locally -- `go build ./...`, `go test ./...`, `go test -race
  ./...`, `gofmt -l` (clean on the two changed files), and `golangci-lint run
  ./pkg/razorpay/...` (clean on the two changed files; a few pre-existing, unrelated
  files in the tree show up as "not gofmt'd" under my Windows checkout purely from
  CRLF line endings -- confirmed via `git stash` that this is unrelated to this diff)

**New/updated tests (`pkg/razorpay/payments_test.go`):**
- `Test_looksLikeUnroutedEndpointError` -- table-driven: the real-world message,
  a case-insensitive variant, two normal Razorpay validation errors that must NOT be
  flagged (including one that happens to contain the word "found"), and an empty
  string.
- `Test_wrapPaymentCreationError` -- confirms guidance is appended only for the
  unrouted-style shape, and normal errors pass through unchanged.
- A new `Test_InitiatePayment` case exercising the real handler end-to-end via the
  existing mock-HTTP-server pattern, asserting the final tool error message contains
  both the original text and the appended guidance.

## Checklist

- [x] I have followed the code style of this project
- [x] I have added comments to code where necessary, particularly in hard-to-understand areas
- [ ] I have updated the documentation where necessary -- N/A, no user-facing docs describe this error path
- [x] I have verified that my changes do not introduce new warnings or errors
- [x] I have checked for and resolved any merge conflicts
- [x] I have considered the performance implications of my changes -- two string
  `Contains` checks only on the error path, no effect on the success path

## Additional Information

I went in expecting to find and fix a routing bug, and came out unable to confirm
one exists in this codebase -- `create_order` works fine through the identical
auth/client/session, which is what pointed me toward an account-level explanation
instead. Filed the issue with full technical detail so a maintainer with visibility
into the hosted deployment/account config can confirm or correct that. This PR is
scoped to the one thing I could verify and fix: the error message itself is
misleading regardless of the root cause.
