### PR TITLE
fix: reject fractional subunit amounts instead of truncating them

### DIFF
--- a/pkg/razorpay/orders.go
+++ b/pkg/razorpay/orders.go
@@ -121,7 +121,7 @@ func CreateOrder(
 		payload := make(map[string]interface{})
 
 		validator := NewValidator(&r).
-			ValidateAndAddRequiredFloat(payload, "amount").
+			ValidateAndAddRequiredInt(payload, "amount").
 			ValidateAndAddRequiredString(payload, "currency").
 			ValidateAndAddOptionalString(payload, "receipt").
 			ValidateAndAddOptionalMap(payload, "notes").
@@ -133,7 +133,7 @@ func CreateOrder(
 
 		// Add first_payment_min_amount only if partial_payment is true
 		if payload["partial_payment"] == true {
-			validator.ValidateAndAddOptionalFloat(payload, "first_payment_min_amount")
+			validator.ValidateAndAddOptionalInt(payload, "first_payment_min_amount")
 		}
 
 		if result, err := validator.HandleErrorsIfAny(); result != nil {

--- a/pkg/razorpay/orders_test.go
+++ b/pkg/razorpay/orders_test.go
@@ -453,6 +453,17 @@ func Test_CreateOrder(t *testing.T) {
 		},
 	}
 
+	tests = append(tests, RazorpayToolTestCase{
+		Name: "fractional amount is rejected",
+		Request: map[string]interface{}{
+			"amount":   float64(100.75),
+			"currency": "INR",
+		},
+		MockHttpClient: nil,
+		ExpectError:    true,
+		ExpectedErrMsg: "invalid parameter type: amount must be a whole number",
+	})
+
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
 			runToolTest(t, tc, CreateOrder, "Order")

--- a/pkg/razorpay/qr_codes.go
+++ b/pkg/razorpay/qr_codes.go
@@ -98,7 +98,7 @@ func CreateQRCode(
 			ValidateAndAddRequiredString(qrData, "usage").
 			ValidateAndAddOptionalString(qrData, "name").
 			ValidateAndAddOptionalBool(qrData, "fixed_amount").
-			ValidateAndAddOptionalFloat(qrData, "payment_amount").
+			ValidateAndAddOptionalInt(qrData, "payment_amount").
 			ValidateAndAddOptionalString(qrData, "description").
 			ValidateAndAddOptionalString(qrData, "customer_id").
 			ValidateAndAddOptionalFloat(qrData, "close_by").

--- a/pkg/razorpay/refunds.go
+++ b/pkg/razorpay/refunds.go
@@ -61,7 +61,7 @@ func CreateRefund(
 
 		validator := NewValidator(&r).
 			ValidateAndAddRequiredString(payload, "payment_id").
-			ValidateAndAddRequiredFloat(payload, "amount").
+			ValidateAndAddRequiredInt(payload, "amount").
 			ValidateAndAddOptionalString(data, "speed").
 			ValidateAndAddOptionalString(data, "receipt").
 			ValidateAndAddOptionalMap(data, "notes")
@@ -70,9 +70,11 @@ func CreateRefund(
 			return result, err
 		}
 
+		// amount is validated as an integer above, so fractional subunit
+		// values are rejected instead of being truncated here.
 		refund, err := client.Payment.Refund(
 			payload["payment_id"].(string),
-			int(payload["amount"].(float64)), data, nil)
+			int(payload["amount"].(int64)), data, nil)
 		if err != nil {
 			return mcpgo.NewToolResultError(
 				formatErrorMessage("creating refund failed", err)), nil

--- a/pkg/razorpay/refunds_test.go
+++ b/pkg/razorpay/refunds_test.go
@@ -117,6 +117,18 @@ func Test_CreateRefund(t *testing.T) {
 			ExpectedErrMsg: "creating refund failed: Razorpay API error: Bad request",
 		},
 		{
+			// Regression test for #134: a fractional subunit amount must be
+			// rejected before any request is made, never truncated to 100.
+			Name: "fractional amount is rejected without calling the API",
+			Request: map[string]interface{}{
+				"payment_id": "pay_29QQoUBi66xm2f",
+				"amount":     float64(100.75),
+			},
+			MockHttpClient: nil,
+			ExpectError:    true,
+			ExpectedErrMsg: "invalid parameter type: amount must be a whole number",
+		},
+		{
 			Name: "multiple validation errors",
 			Request: map[string]interface{}{
 				// Missing payment_id parameter

--- a/pkg/razorpay/tools_params.go
+++ b/pkg/razorpay/tools_params.go
@@ -3,6 +3,7 @@ package razorpay
 import (
 	"encoding/json"
 	"errors"
+	"math"
 	"strings"
 	"time"
 
@@ -79,10 +80,27 @@ func extractValueGeneric[T any](
 
 	err = json.Unmarshal(data, &result)
 	if err != nil {
+		if isFractionalForInteger[T](val) {
+			return nil, errors.New("invalid parameter type: " + name +
+				" must be a whole number")
+		}
 		return nil, errors.New("invalid parameter type: " + name)
 	}
 
 	return &result, nil
+}
+
+// isFractionalForInteger reports whether an integer was expected but the
+// caller sent a number with a fractional part (e.g. 100.75 paise). Amounts in
+// currency subunits are integers, so such input is rejected instead of being
+// silently truncated.
+func isFractionalForInteger[T any](val interface{}) bool {
+	var zero T
+	if _, isInt := any(zero).(int64); !isInt {
+		return false
+	}
+	f, isFloat := val.(float64)
+	return isFloat && f != math.Trunc(f)
 }
 
 // Generic validation functions

--- a/pkg/razorpay/tools_params_test.go
+++ b/pkg/razorpay/tools_params_test.go
@@ -85,6 +85,34 @@ func TestValidator(t *testing.T) {
 			expectKey:      "test_param",
 		},
 
+		{
+			name:           "required int - fractional",
+			args:           map[string]interface{}{"test_param": float64(100.75)},
+			paramName:      "test_param",
+			validationFunc: (*Validator).ValidateAndAddRequiredInt,
+			expectError:    true,
+			expectValue:    nil,
+			expectKey:      "test_param",
+		},
+		{
+			name:           "optional int - fractional",
+			args:           map[string]interface{}{"test_param": float64(0.5)},
+			paramName:      "test_param",
+			validationFunc: (*Validator).ValidateAndAddOptionalInt,
+			expectError:    true,
+			expectValue:    nil,
+			expectKey:      "test_param",
+		},
+		{
+			name:           "required int - whole float is accepted",
+			args:           map[string]interface{}{"test_param": float64(500100)},
+			paramName:      "test_param",
+			validationFunc: (*Validator).ValidateAndAddRequiredInt,
+			expectError:    false,
+			expectValue:    int64(500100),
+			expectKey:      "test_param",
+		},
+
 		// Float tests
 		{
 			name:           "required float - valid",


### PR DESCRIPTION
## Description
`create_refund` validated `amount` with `ValidateAndAddRequiredFloat` and then did `int(payload["amount"].(float64))` before calling the SDK. A request for `100.75` paise was therefore silently sent to Razorpay as `100`. Amounts in currency subunits are integers, so fractional input should be rejected at the MCP boundary, never changed.

This PR:
- validates `amount` in `create_refund` as an integer and passes it through without a float cast;
- applies the same rule to the other subunit amounts that used the float validator: `create_order` (`amount`, `first_payment_min_amount`) and `create_qr_code` (`payment_amount`);
- makes the validator say `invalid parameter type: amount must be a whole number` when an integer parameter receives a fractional value, so an agent gets an actionable message instead of a generic type error. `NaN`, infinities and out-of-range values were already rejected by the `int64` JSON round-trip, and still are.

No tool schema changes; whole numbers sent as JSON numbers (e.g. `500100`) behave exactly as before.

## Related Issues
Fixes #134

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] Added unit tests
  - `Test_CreateRefund/fractional amount is rejected without calling the API` (`100.75`, no mock server, validation error returned)
  - `Test_CreateOrder/fractional amount is rejected`
  - `TestValidator`: required/optional int with fractional input fails, whole float `500100` still maps to `int64`
- [x] All tests pass locally: `go test -race ./...`
- [x] `gofmt`, `go vet` and `golangci-lint` v1.64.8 (the CI version) are clean

## Checklist
- [x] I have followed the code style of this project
- [x] I have added comments to code where necessary, particularly in hard-to-understand areas
- [x] I have verified that my changes do not introduce new warnings or errors
- [x] I have checked for and resolved any merge conflicts
- [x] I have considered the performance implications of my changes

## Additional Information
The `Min(100)` constraint and the tool descriptions already say amounts are in paise; this change makes the runtime match that contract. Existing tests pass unchanged because they all send whole-number amounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtpcFAThUxrGAyCyxiiEC5
