### PR TITLE
fix: retain every value passed to the expand parameter

### DIFF
--- a/pkg/razorpay/orders_test.go
+++ b/pkg/razorpay/orders_test.go
@@ -1,11 +1,15 @@
 package razorpay
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
+	rzpsdk "github.com/razorpay/razorpay-go"
 	"github.com/razorpay/razorpay-go/constants"
 
 	"github.com/razorpay/razorpay-mcp-server/pkg/razorpay/mock"
@@ -977,4 +981,42 @@ func Test_UpdateOrder(t *testing.T) {
 			runToolTest(t, tc, UpdateOrder, "Order")
 		})
 	}
+}
+
+// Test_FetchAllOrders_ExpandQueryParams asserts that every value supplied to
+// expand reaches the outgoing request. The validator writes the slice into the
+// params map and the SDK serialises it as expand[]=a&expand[]=b, so this covers
+// both halves together; asserting on the params map alone would not catch a
+// regression in how the value is shaped.
+func Test_FetchAllOrders_ExpandQueryParams(t *testing.T) {
+	var capturedQuery string
+
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			capturedQuery = r.URL.RawQuery
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"entity":"collection","count":0,"items":[]}`))
+		}))
+	defer server.Close()
+
+	client := rzpsdk.NewClient("sample_key", "sample_secret")
+	client.Order.Request.BaseURL = server.URL
+	client.Order.Request.HTTPClient = server.Client()
+
+	tool := FetchAllOrders(CreateTestObservability(), client)
+	request := createMCPRequest(map[string]interface{}{
+		"expand": []interface{}{"payments", "transfers", "virtual_account"},
+	})
+
+	_, err := tool.GetHandler()(context.Background(), request)
+	assert.NoError(t, err)
+
+	// url.Values.Encode escapes the brackets, so expand[] becomes expand%5B%5D
+	assert.Equal(t,
+		"expand%5B%5D=payments&expand%5B%5D=transfers"+
+			"&expand%5B%5D=virtual_account",
+		capturedQuery,
+		"every expand value should reach the request",
+	)
 }

--- a/pkg/razorpay/tools_params.go
+++ b/pkg/razorpay/tools_params.go
@@ -247,7 +247,10 @@ func (v *Validator) ValidateAndAddPagination(
 		ValidateAndAddOptionalInt(params, "skip")
 }
 
-// ValidateAndAddExpand validates and adds expand parameters
+// ValidateAndAddExpand validates and adds expand parameters.
+// The full slice is passed through so that the SDK can serialise it as
+// expand[]=val1&expand[]=val2; assigning one value at a time would leave
+// only the last one.
 func (v *Validator) ValidateAndAddExpand(
 	params map[string]interface{},
 ) *Validator {
@@ -261,9 +264,7 @@ func (v *Validator) ValidateAndAddExpand(
 	}
 
 	if len(*expand) > 0 {
-		for _, val := range *expand {
-			params["expand[]"] = val
-		}
+		params["expand[]"] = *expand
 	}
 	return v
 }

--- a/pkg/razorpay/tools_params_test.go
+++ b/pkg/razorpay/tools_params_test.go
@@ -339,25 +339,33 @@ func TestValidatorExpand(t *testing.T) {
 	tests := []struct {
 		name         string
 		args         map[string]interface{}
-		expectExpand string
+		expectExpand []string
 		expectError  bool
 	}{
 		{
 			name:         "valid expand param",
 			args:         map[string]interface{}{"expand": []interface{}{"payments"}},
-			expectExpand: "payments",
+			expectExpand: []string{"payments"},
+			expectError:  false,
+		},
+		{
+			name: "multiple expand params are all retained",
+			args: map[string]interface{}{
+				"expand": []interface{}{"payments", "transfers", "virtual_account"},
+			},
+			expectExpand: []string{"payments", "transfers", "virtual_account"},
 			expectError:  false,
 		},
 		{
 			name:         "empty expand array",
 			args:         map[string]interface{}{"expand": []interface{}{}},
-			expectExpand: "",
+			expectExpand: nil,
 			expectError:  false,
 		},
 		{
 			name:         "invalid expand type",
 			args:         map[string]interface{}{"expand": "not an array"},
-			expectExpand: "",
+			expectExpand: nil,
 			expectError:  true,
 		},
 	}
@@ -376,7 +384,7 @@ func TestValidatorExpand(t *testing.T) {
 				assert.True(t, validator.HasErrors(), "Expected validation error")
 			} else {
 				assert.False(t, validator.HasErrors(), "Did not expect validation error")
-				if tt.expectExpand != "" {
+				if len(tt.expectExpand) > 0 {
 					assert.Equal(t,
 						tt.expectExpand,
 						result["expand[]"],
@@ -999,8 +1007,8 @@ func TestValidateAndAddExpand(t *testing.T) {
 		validator := NewValidator(request).ValidateAndAddExpand(params)
 
 		assert.False(t, validator.HasErrors())
-		// The function sets expand[] for each value, so check the last one
-		assert.Equal(t, "customer", params["expand[]"])
+		// Every requested value must survive, not just the last one.
+		assert.Equal(t, []string{"payments", "customer"}, params["expand[]"])
 	})
 
 	t.Run("missing expand parameter", func(t *testing.T) {


### PR DESCRIPTION
## What

`ValidateAndAddExpand` assigns every element of the `expand` slice to the same
`params["expand[]"]` key, so each iteration overwrites the previous one. Only the
last value survives, and nothing errors — the caller has no way to tell the rest
were dropped.

```go
// pkg/razorpay/tools_params.go
if len(*expand) > 0 {
    for _, val := range *expand {
        params["expand[]"] = val   // same key every iteration
    }
}
```

This affects the two tools that expose `expand`:

- `fetch_all_orders` (`pkg/razorpay/orders.go`)
- `fetch_all_instant_settlements` (`pkg/razorpay/settlements.go`)

In practice `expand` has never worked for more than one value.

## Why this fix

The SDK already knows how to serialise this. `buildURLWithParams` in
`razorpay-go/requests/request.go` special-cases `[]string` and emits
`key[]=val1&key[]=val2`, with a comment stating this is the expected pattern for
Razorpay APIs:

```go
// Handle string arrays specially to follow the format key[]=val1&key[]=val2
// This is a common pattern in rzp APIs
if stringArray, isStringArray := v.([]string); isStringArray {
    for _, item := range stringArray {
        parameters.Add(k, item)
    }
    continue
}
```

So the fix is to stop flattening the value, not to add new serialisation logic:

```go
if len(*expand) > 0 {
    params["expand[]"] = *expand
}
```

Both affected call sites reach that path — `Order.All` and
`Settlement.FetchAllOnDemandSettlement` both delegate to `Request.Get`, which
calls `buildURLWithParams`.

## Verified against the outgoing request

I checked this at the HTTP layer rather than by asserting on the params map,
using a test server that captures the raw query string and driving the real
`fetch_all_orders` handler with three expand values:

| | Query string actually sent |
|---|---|
| before | `expand%5B%5D=virtual_account` |
| after | `expand%5B%5D=payments&expand%5B%5D=transfers&expand%5B%5D=virtual_account` |

(`%5B%5D` is `[]` after `url.Values.Encode`.)

`Test_FetchAllOrders_ExpandQueryParams` in `orders_test.go` locks this in. It
covers the validator and the SDK serialisation together, because asserting on
the params map alone would still pass if the value were shaped wrongly.

## Tests

The existing unit tests asserted the old behaviour, including this comment:

```go
// The function sets expand[] for each value, so check the last one
assert.Equal(t, "customer", params["expand[]"])
```

Those assertions now require every value to survive, and `TestValidatorExpand`
gains a multi-value case that fails without this change:

```go
{
    name: "multiple expand params are all retained",
    args: map[string]interface{}{
        "expand": []interface{}{"payments", "transfers", "virtual_account"},
    },
    expectExpand: []string{"payments", "transfers", "virtual_account"},
    expectError:  false,
},
```

## Checks run

- `go test ./...` — all 9 packages pass
- `go vet ./...` — clean
- `gofmt` — no changes wanted in the touched files

One thing I could not run locally: `go test -race`, which needs cgo and a C
toolchain I do not have on this machine. CI should cover it.

## Scope

Three files, one behavioural change, no API surface change. `expand` is already
declared as an array in the tool schemas, so this only makes the implementation
match the contract that was already documented.
