### PR TITLE
fix: do not panic on unexpected shapes in the payment response

### DIFF
--- a/pkg/razorpay/payments.go
+++ b/pkg/razorpay/payments.go
@@ -334,10 +334,12 @@ func FetchAllPayments(
 	)
 }
 
-// extractPaymentID extracts the payment ID from the payment response
+// extractPaymentID extracts the payment ID from the payment response.
+// A missing, null or non-string id yields the empty string rather than a
+// panic, since the value comes from the API response and is not validated.
 func extractPaymentID(payment map[string]interface{}) string {
-	if id, exists := payment["razorpay_payment_id"]; exists && id != nil {
-		return id.(string)
+	if id, ok := payment["razorpay_payment_id"].(string); ok {
+		return id
 	}
 	return ""
 }
@@ -431,25 +433,33 @@ func buildInitiatePaymentResponse(
 		hasUPIIntent := false
 
 		for _, action := range actions {
-			if actionType, exists := action["action"]; exists {
-				actionStr := actionType.(string)
-				actionTypes = append(actionTypes, actionStr)
-				if actionStr == "otp_generate" {
-					hasOTP = true
-					otpUrl = action["url"].(string)
-				}
+			// Values here come from the API response, so an entry with a
+			// missing or non-string action is skipped rather than asserted.
+			actionStr, ok := action["action"].(string)
+			if !ok {
+				continue
+			}
 
-				if actionStr == "redirect" {
-					hasRedirect = true
+			actionTypes = append(actionTypes, actionStr)
+			if actionStr == "otp_generate" {
+				hasOTP = true
+				// A missing url leaves otpUrl empty; processPaymentResult
+				// already skips the OTP request in that case.
+				if url, ok := action["url"].(string); ok {
+					otpUrl = url
 				}
+			}
 
-				if actionStr == "upi_collect" {
-					hasUPICollect = true
-				}
+			if actionStr == "redirect" {
+				hasRedirect = true
+			}
 
-				if actionStr == "upi_intent" {
-					hasUPIIntent = true
-				}
+			if actionStr == "upi_collect" {
+				hasUPICollect = true
+			}
+
+			if actionStr == "upi_intent" {
+				hasUPIIntent = true
 			}
 		}
 

--- a/pkg/razorpay/payments_test.go
+++ b/pkg/razorpay/payments_test.go
@@ -1811,6 +1811,22 @@ func Test_extractPaymentID(t *testing.T) {
 			payment:  map[string]interface{}{},
 			expected: "",
 		},
+		{
+			name: "numeric payment ID",
+			payment: map[string]interface{}{
+				"razorpay_payment_id": float64(12345),
+				"status":              "created",
+			},
+			expected: "",
+		},
+		{
+			name: "payment ID of an unexpected shape",
+			payment: map[string]interface{}{
+				"razorpay_payment_id": map[string]interface{}{"id": "pay_x"},
+				"status":              "created",
+			},
+			expected: "",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1938,6 +1954,41 @@ func Test_buildInitiatePaymentResponse(t *testing.T) {
 				},
 			},
 			expectedMsg:    "Payment initiated. Available actions: [unknown_action]",
+			expectedOtpURL: "",
+		},
+		{
+			// The action arrives without the url the OTP flow needs. The
+			// action itself is still reported; otpUrl stays empty and
+			// processPaymentResult skips the OTP request.
+			name: "otp_generate action missing its url",
+			payment: map[string]interface{}{
+				"id":     "pay_MT48CvBhIC98MQ",
+				"status": "created",
+			},
+			paymentID: "pay_MT48CvBhIC98MQ",
+			actions: []map[string]interface{}{
+				{"action": "otp_generate"},
+			},
+			expectedMsg: "Payment initiated. OTP authentication is available. " +
+				"Use the 'submit_otp' tool to submit OTP received by the customer " +
+				"for authentication.",
+			expectedOtpURL: "",
+		},
+		{
+			// A non-string action value is skipped rather than asserted.
+			name: "action value is not a string",
+			payment: map[string]interface{}{
+				"id":     "pay_MT48CvBhIC98MQ",
+				"status": "created",
+			},
+			paymentID: "pay_MT48CvBhIC98MQ",
+			actions: []map[string]interface{}{
+				{
+					"action": float64(42),
+					"url":    "https://api.razorpay.com/v1/payments/x/otp_generate",
+				},
+			},
+			expectedMsg:    "Payment initiated. Available actions: []",
 			expectedOtpURL: "",
 		},
 	}


### PR DESCRIPTION
## What

Three type assertions in `payments.go` read values straight out of the Razorpay
API response without checking the type first. Each panics if the field is
missing or arrives with a different type:

| line (main) | location | assertion |
|---|---|---|
| 340 | `extractPaymentID` | `id.(string)` |
| 435 | action loop in `buildInitiatePaymentResponse` | `actionType.(string)` |
| 439 | same loop | `action["url"].(string)` |

Unlike the assertions elsewhere in this package, these values have not been
through `Validator`, so nothing guarantees their type.

## Why it matters

A panic here terminates the process. The server does not enable mcp-go's
`WithRecovery()` middleware, and those two `recover()` calls are the only ones
in the whole `mark3labs/mcp-go` module — nothing else in the request path
catches it. An unrecovered panic in any goroutine takes the process down, so a
single malformed response ends the session rather than returning an error.

The `url` case needs no exotic input. The code checks only that the action is
`otp_generate`, then reads `action["url"]` unconditionally:

```go
if actionStr == "otp_generate" {
    hasOTP = true
    otpUrl = action["url"].(string)   // nil if "url" is absent
}
```

An `otp_generate` entry without a `url` is enough.

## Reproduction

Driving the real `initiate_payment` handler against a test server returning
these bodies:

| response | panic |
|---|---|
| `{"razorpay_payment_id": 12345}` | `interface conversion: interface {} is float64, not string` |
| `{"next":[{"action": 42, "url": "..."}]}` | `interface conversion: interface {} is float64, not string` |
| `{"next":[{"action": "otp_generate"}]}` | `interface conversion: interface {} is nil, not string` |

## The fix

All three now use comma-ok. This is the pattern the package already uses —
`extractNextActions` sits directly below `extractPaymentID` and checks both its
assertions, and the `customer["id"].(string)` lookup in `InitiatePayment` does
the same. These three are the inconsistency, not the fix.

Behaviour on malformed input:

- a non-string payment id yields `""`, matching what a missing id already did
- an action whose `action` value is not a string is skipped
- an `otp_generate` action with no `url` leaves `otpUrl` empty, which
  `processPaymentResult` already handles with `if otpUrl != ""`

No behaviour changes for well-formed responses.

## Tests

Cases added to the two existing table tests:

- `Test_extractPaymentID` — numeric id, and an id of an unexpected shape
- `Test_buildInitiatePaymentResponse` — `otp_generate` missing its url, and a
  non-string action value

Each of these panics against the unmodified code, so they fail without this
change rather than merely passing alongside it.

## Checks run

- `go test ./...` — all 9 packages pass
- `go vet ./...` — clean
- `gofmt` — no changes wanted in the touched files

I could not run `go test -race` locally, as it needs cgo and a C toolchain I do
not have on this machine. CI should cover it.

## Scope

Two files. One behavioural change, confined to how malformed responses are
handled; well-formed responses take exactly the same path as before.
